### PR TITLE
Testing navigation and updates to tester

### DIFF
--- a/launch/navigation.launch.xml
+++ b/launch/navigation.launch.xml
@@ -1,0 +1,17 @@
+<!-- ROS launchfile for testing local navigation
+ 
+ Author:
+    Annaleah Ernst
+ -->
+
+<launch>
+    <!-- Set up mappings for the localization package -->
+    <remap from="mobile_base/sensors/imu_data" to="imu_data" />
+    <remap from="mobile_base/odom" to="odom" />
+
+    <!-- Launch Turtlebot -->
+    <include file="$(find turtlebot_bringup)/launch/minimal.launch" />
+    
+    <!-- Launch localization package -->
+    <include file="robot_pose_ekf.launch.xml" />
+</launch>

--- a/launch/robot_pose_ekf.launch.xml
+++ b/launch/robot_pose_ekf.launch.xml
@@ -1,0 +1,11 @@
+<launch>
+  <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">
+    <param name="freq" value="10.0"/>
+    <param name="sensor_timeout" value="1.0"/>
+    <param name="publish_tf" value="true"/>
+    <param name="odom_used" value="true"/>
+    <param name="imu_used" value="true"/>
+    <param name="vo_used" value="false"/>
+    <param name="output_frame" value="odom"/>
+  </node>
+</launch>

--- a/motion.py
+++ b/motion.py
@@ -116,6 +116,12 @@ class Motion():
         self._move_cmd.angular.z = 0
         self._publish()
 
+    def shutdown(self, rate):
+        """ Bring the robot to a gentle stop. """
+        while self.walking:
+            self.stop()
+            rate.sleep()
+
 if __name__ == "__main__":
     from tester import Tester
     from sensors import Sensors
@@ -126,7 +132,7 @@ if __name__ == "__main__":
         def __init__(self):
             # set up basic sensing
             self.sensors = Sensors()
-            self.motion = motion
+            self.motion = Motion()
             
             Tester.__init__(self, "Motion")
         
@@ -146,11 +152,8 @@ if __name__ == "__main__":
                 self.motion.walk()
 
         def shutdown(self):
-            """ Bring robot to a gentle stop. """
-            while self.motion.walking:
-                self.motion.stop()
-                self.rate.sleep()
-            
+            """ Shutdown test. """
+            self.motion.shutdown(self.rate)
             Tester.shutdown(Self)
                 
     MotionTest()

--- a/motion.py
+++ b/motion.py
@@ -126,6 +126,7 @@ if __name__ == "__main__":
         def __init__(self):
             # set up basic sensing
             self.sensors = Sensors()
+            self.motion = motion
             
             Tester.__init__(self, "Motion")
         
@@ -143,5 +144,13 @@ if __name__ == "__main__":
             # otherwise, just walk
             else:
                 self.motion.walk()
+
+        def shutdown(self):
+            """ Bring robot to a gentle stop. """
+            while self.motion.walking:
+                self.motion.stop()
+                self.rate.sleep()
+            
+            Tester.shutdown(Self)
                 
     MotionTest()

--- a/motion.py
+++ b/motion.py
@@ -154,6 +154,6 @@ if __name__ == "__main__":
         def shutdown(self):
             """ Shutdown test. """
             self.motion.shutdown(self.rate)
-            Tester.shutdown(Self)
+            Tester.shutdown(self)
                 
     MotionTest()

--- a/navigation.py
+++ b/navigation.py
@@ -29,7 +29,7 @@ class Navigation():
     def _ekfCallback(self, data):
         self.p = data.pose.pose.position
         self.q = data.pose.pose.orientation
-        self._logger.debug(tf.transformations.tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w]))
+        self._logger.debug(tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w]))
 
 if __name__ == "__main__":
     from tester import Tester

--- a/navigation.py
+++ b/navigation.py
@@ -4,20 +4,32 @@ Author:
     Annaleah Ernst
 """
 import rospy
+import tf
 
-from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import PoseWithCovarianceStamped, Point, Quaternion
 
 from logger import Logger
 
 class Navigation():
-    """ """
+    """ Local navigation.
+    
+    Attributes:
+        p (geometry_msgs.msg.Point): The position of the robot in the odometry frame according to
+            the robot_pose_ekf package.
+        q (geometry_msgs.msg.Quaternion): The orientation of the robot in the odometry frame
+            according the the robot_pose_ekf package.
+    """
     def __init__(self):
         self._logger = Logger("Navigation")
 
+        self.p = None
+        self.q = None
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
 
     def _ekfCallback(self, data):
-        self._logger.debug(data)
+        self.p = data.pose.pose.position
+        self.q = data.pose.pose.orientation
+        self._logger.debug(tf.transformations.tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w]))
 
 if __name__ == "__main__":
     from tester import Tester

--- a/navigation.py
+++ b/navigation.py
@@ -18,7 +18,7 @@ class Navigation():
             the robot_pose_ekf package.
         q (geometry_msgs.msg.Quaternion): The orientation of the robot in the odometry frame
             according the the robot_pose_ekf package.
-        angle (float): The angle (in radians) that the robot is from 0.
+        angle (float): The angle (in radians) that the robot is from 0. Between -pi and pi
     """
     def __init__(self):
         self._logger = Logger("Navigation")
@@ -31,8 +31,8 @@ class Navigation():
         self.p = data.pose.pose.position
         self.q = data.pose.pose.orientation
         
-        # since a quaternion respresents 3d space, and turtlebot motion is in 2d,
-        # we can just extract the only non zero euler angle
+        # since a quaternion respresents 3d space, and turtlebot motion is in 2d, we can just
+        # extract the only non zero euler angle as the angle of rotation in the floor plane
         self.angle = tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w])[-1]
 
 if __name__ == "__main__":

--- a/navigation.py
+++ b/navigation.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
 
     class NavigationTest(Tester):
         def __init__(self):
+            self.navigation = Navigation()
             Tester.__init__(self, "Navigation")
 
         def main(self):

--- a/navigation.py
+++ b/navigation.py
@@ -18,6 +18,7 @@ class Navigation():
             the robot_pose_ekf package.
         q (geometry_msgs.msg.Quaternion): The orientation of the robot in the odometry frame
             according the the robot_pose_ekf package.
+        angle (float): The angle (in radians) that the robot is from 0.
     """
     def __init__(self):
         self._logger = Logger("Navigation")
@@ -29,7 +30,10 @@ class Navigation():
     def _ekfCallback(self, data):
         self.p = data.pose.pose.position
         self.q = data.pose.pose.orientation
-        self._logger.debug(tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w]))
+        
+        # since a quaternion respresents 3d space, and turtlebot motion is in 2d,
+        # we can just extract the only non zero euler angle
+        self.angle = tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w])[-1]
 
 if __name__ == "__main__":
     from tester import Tester
@@ -40,6 +44,7 @@ if __name__ == "__main__":
             Tester.__init__(self, "Navigation")
 
         def main(self):
+            self.logger.debug(self.navigation.angle)
             pass
 
     NavigationTest()

--- a/navigation.py
+++ b/navigation.py
@@ -1,0 +1,30 @@
+""" Local navigation using robot_pose_ekf
+    
+Author:
+    Annaleah Ernst
+"""
+import rospy
+
+from geometry_msgs.msg import PoseWithCovarianceStamped
+
+from logger import Logger():
+
+class Navigation():
+    """ """
+    def __init__(self):
+        self._logger = Logger("Navigation")
+
+        rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
+
+    def _ekfCallback(self, data):
+        self._logger.debug(data)
+
+if __name__ == "__main__":
+    from tester import Tester
+
+    class NavigationTest(Tester):
+        def __init__(self):
+            Tester.__init__(self, "Navigation")
+
+        def main(self):
+            pass

--- a/navigation.py
+++ b/navigation.py
@@ -7,7 +7,7 @@ import rospy
 
 from geometry_msgs.msg import PoseWithCovarianceStamped
 
-from logger import Logger():
+from logger import Logger
 
 class Navigation():
     """ """

--- a/navigation.py
+++ b/navigation.py
@@ -28,3 +28,5 @@ if __name__ == "__main__":
 
         def main(self):
             pass
+
+    NavigationTest()

--- a/tester.py
+++ b/tester.py
@@ -7,7 +7,6 @@ Author:
 import rospy
 
 from logger import Logger
-from motion import Motion
 
 class Tester():
     """
@@ -18,7 +17,6 @@ class Tester():
         
     Attributes:
         logger (Logger): A custom logger for the tester.
-        motion (Motion): Acess to the motion module for robot movement.
         rate (rospy.Rate): Used to control the refresh rate of robot control loops.
         
     Note: When inheriting from the Tester class, its initialization sequence should be
@@ -36,9 +34,6 @@ class Tester():
         
         # set global test refresh rate (100 Hz)
         self.rate = rospy.Rate(100)
-        
-        # set up motion module
-        self.motion = Motion()
     
         # set up test node logger
         self.logger = Logger(self.__name__)
@@ -61,10 +56,6 @@ class Tester():
         
         Note: This function may be overridden in the subclasses.
         """
-        while self.motion.walking:
-            self.motion.stop()
-            self.rate.sleep()
-        
         self.logger.info("goodbye world")
 
     def signal_shutdown(self, reason):


### PR DESCRIPTION
Begin work on the navigation module, including creating appropriate launch files. 
Minor updates to the tester base class: removal of motion module from the tester. Navigation must inherit from the motion module (or contain a motion module), and it is redundant to have both. We will put of integration of motion until a later date.