### PR TITLE
Added turn wrapping

### DIFF
--- a/navigation.py
+++ b/navigation.py
@@ -72,6 +72,6 @@ if __name__ == "__main__":
         def main(self):
             self.logger.debug(self.navigation.angle, var_name = "cur_angle")
             self.logger.debug(self.navigation.wrapTurnAngle(-2), var_name="-2")
-            self.logger.debug(self.navigation.wrapTurnAngle(-2), var_name="-2")
+            self.logger.debug(self.navigation.wrapTurnAngle(2), var_name="2")
 
     NavigationTest()

--- a/navigation.py
+++ b/navigation.py
@@ -40,7 +40,7 @@ class Navigation():
         # extract the only non zero euler angle as the angle of rotation in the floor plane
         self.angle = tf.transformations.euler_from_quaternion([self.q.x, self.q.y, self.q.z, self.q.w])[-1]
 
-    def convertTurnAngle(self, turn):
+    def wrapTurnAngle(self, turn):
         """ Wrap around the pi to back to -pi, if necessary
     
         If the angles are in adjacent quadrants where the angles wrap around (since we go from -pi to pi),

--- a/navigation.py
+++ b/navigation.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
             Tester.__init__(self, "Navigation")
 
         def main(self):
-            self.logger.debug(self.navigation.angle)
-            pass
+            self.logger.debug(self.navigation.angle, var_name = "cur_angle")
+            self.logger.debug(self.navigation.wrapTurnAngle(-2), var_name="-2")
+            self.logger.debug(self.navigation.wrapTurnAngle(-2), var_name="-2")
 
     NavigationTest()


### PR DESCRIPTION
Added function to wrap turn angles if comparing angles in adjacent quadrants at the flip point; since the angle flips from -pi to pi, but -pi is adjacent to pi, we need to take this into account when doing calculations.