### PR TITLE
Zero Odometry

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -100,4 +100,4 @@ if __name__ == "__main__":
 
             self.signal_shutdown("Logger test complete.")
 
-    LoggerTest()
+    LoggerTest().run()

--- a/motion.py
+++ b/motion.py
@@ -198,4 +198,4 @@ if __name__ == "__main__":
             self.motion.shutdown(self.rate)
             Tester.shutdown(self)
                 
-    MotionTest()
+    MotionTest().run()

--- a/motion.py
+++ b/motion.py
@@ -159,11 +159,11 @@ if __name__ == "__main__":
         """ Run unit test for the motion class. """
         
         def __init__(self):
+            Tester.__init__(self, "Motion")
+            
             # set up basic sensing
             self.sensors = Sensors()
             self.motion = Motion()
-            
-            Tester.__init__(self, "Motion")
         
         def main(self):
             """ The main control loop. """

--- a/navigation.py
+++ b/navigation.py
@@ -36,8 +36,8 @@ class Navigation():
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
     
         # reset Turtlebot odometry information on launch
-        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
         while self.p is None:
+            reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
             reset.publish(Empty())
 
     def _ekfCallback(self, data):
@@ -106,12 +106,8 @@ if __name__ == "__main__":
         def main(self):
             """ The test currently being run. """
             #self.testCCsquare(.5)
-            #self.testCsquare(.5)
+            self.testCsquare(.5)
             #self.testLine(1)
-            
-            # reset Turtlebot odometry information on launch
-            reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
-            reset.publish(Empty())
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 

--- a/navigation.py
+++ b/navigation.py
@@ -26,7 +26,7 @@ class Navigation():
     _HALF_PI = pi / 2.0
     _TWO_PI = 2.0 * pi
     
-    def __init__(self):
+    def __init__(self, rate):
         self._logger = Logger("Navigation")
 
         # subscibe to the robot_pose_ekf odometry information
@@ -39,6 +39,7 @@ class Navigation():
         while self.p is None:
             reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
             reset.publish(Empty())
+            rate.sleep()
 
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """
@@ -89,7 +90,7 @@ if __name__ == "__main__":
         def __init__(self):
             Tester.__init__(self, "Navigation")
             
-            self.navigation = Navigation()
+            self.navigation = Navigation(self.rate)
             self.motion = SafeMotion(0)
             
             self.stopping = False

--- a/navigation.py
+++ b/navigation.py
@@ -106,8 +106,8 @@ if __name__ == "__main__":
         def main(self):
             """ The test currently being run. """
             #self.testCCsquare(.5)
-            # self.testCsquare(.5)
-            self.testLine(1)
+            self.testCsquare(.5)
+            #self.testLine(1)
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 

--- a/navigation.py
+++ b/navigation.py
@@ -32,11 +32,12 @@ class Navigation():
         # reset Turtlebot odometry information on launch
         reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
         reset.publish(Empty())
-        rospy.sleep(2)
+        rospy.sleep(1)
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = Point(0,0,0)
         self.q = Quaternion(0,0,0,1)
+        self.angle = 0
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
 
     def _ekfCallback(self, data):

--- a/navigation.py
+++ b/navigation.py
@@ -10,6 +10,7 @@ import numpy as np
 from geometry_msgs.msg import PoseWithCovarianceStamped, Point, Quaternion
 from math import atan2, pi
 from std_msgs.msg import Empty
+from time import time
 
 from logger import Logger
 
@@ -26,7 +27,7 @@ class Navigation():
     _HALF_PI = pi / 2.0
     _TWO_PI = 2.0 * pi
     
-    def __init__(self, rate):
+    def __init__(self):
         self._logger = Logger("Navigation")
 
         # subscibe to the robot_pose_ekf odometry information
@@ -36,10 +37,10 @@ class Navigation():
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
     
         # reset Turtlebot odometry information on launch
-        while not rospy.is_shutdown():
-            reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        timer = time()
+        while time() - timer < 1 or self.p is None:
             reset.publish(Empty())
-            rate.sleep()
 
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """
@@ -90,7 +91,7 @@ if __name__ == "__main__":
         def __init__(self):
             Tester.__init__(self, "Navigation")
             
-            self.navigation = Navigation(self.rate)
+            self.navigation = Navigation()
             self.motion = SafeMotion(0)
             
             self.stopping = False

--- a/navigation.py
+++ b/navigation.py
@@ -39,6 +39,9 @@ class Navigation():
         # set up the odometry reset publisher (publishing Empty messages here will reset odom)
         self.reset_odom = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=1)
         self.reset_odom.publish(Empty())
+    
+        while self.p is None:
+            pass
         
 #        # reset odometry (these messages take a few iterations to get through)
 #        timer = time()

--- a/navigation.py
+++ b/navigation.py
@@ -28,16 +28,17 @@ class Navigation():
     
     def __init__(self):
         self._logger = Logger("Navigation")
-        
-        # reset Turtlebot odometry information on launch
-        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
-        reset.publish(Empty())
 
         # subscibe to the robot_pose_ekf odometry information
-        self.p = Point(0,0,0)
-        self.q = Quaternion(0,0,0,1)
+        self.p = None
+        self.q = None
         self.angle = 0
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
+    
+        # reset Turtlebot odometry information on launch
+        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        while self.p is None:
+            reset.publish(Empty())
 
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """

--- a/navigation.py
+++ b/navigation.py
@@ -28,10 +28,6 @@ class Navigation():
     
     def __init__(self):
         self._logger = Logger("Navigation")
-        
-        # reset the Turtlebot odometry
-        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
-        reset.publish(Empty)
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = None
@@ -105,7 +101,10 @@ if __name__ == "__main__":
             """ The test currently being run. """
             # self.testCCsquare(.5)
             # self.testCsquare(.5)
-            self.testLine(1)
+            # self.testLine(1)
+            # reset the Turtlebot odometry
+            reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+            reset.publish(Empty)
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 

--- a/navigation.py
+++ b/navigation.py
@@ -32,6 +32,7 @@ class Navigation():
         # reset Turtlebot odometry information on launch
         reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
         reset.publish(Empty())
+        rospy.sleep(1)
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = None

--- a/navigation.py
+++ b/navigation.py
@@ -152,9 +152,9 @@ if __name__ == "__main__":
                 length (float): Length of the desired line (in meters).
             """
             if not self.reached_goal:
-                self.reached_goal = self.goToPos("end point", length, 0)
+                self.reached_goal = self.gotToPos("end point", length, 0)
             else:
-                self.reached_goal = self.goToPos("home", 0, 0)
+                self.reached_goal = self.gotToPos("home", 0, 0)
     
         def testCCsquare(self, length):
             """ Test a counter clockwise square. """

--- a/navigation.py
+++ b/navigation.py
@@ -41,7 +41,7 @@ class Navigation():
         
         # reset odometry (these messages take a few iterations to get through)
         timer = time()
-        while time() - timer < 0.1 or self.p is None:
+        while time() - timer < 0.25 or self.p is None:
             self.reset_odom.publish(Empty())
 
     def _ekfCallback(self, data):

--- a/navigation.py
+++ b/navigation.py
@@ -28,6 +28,10 @@ class Navigation():
     
     def __init__(self):
         self._logger = Logger("Navigation")
+        
+        # reset Turtlebot odometry information on launch
+        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        reset.publish(Empty())
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = None
@@ -81,6 +85,8 @@ if __name__ == "__main__":
     class NavigationTest(Tester):
         """ Run local navigation tests. """
         def __init__(self):
+            Tester.__init__(self, "Navigation")
+            
             self.navigation = Navigation()
             self.motion = SafeMotion(0)
             
@@ -94,17 +100,12 @@ if __name__ == "__main__":
             self.cc_square = [(0,0), (1,0), (1,1), (0,1)]
             self.c_square = [(0,0), (0,1), (1,1), (1,0)]
             self.corner_counter = 0
-            
-            Tester.__init__(self, "Navigation")
 
         def main(self):
             """ The test currently being run. """
-            # self.testCCsquare(.5)
+            self.testCCsquare(.5)
             # self.testCsquare(.5)
             # self.testLine(1)
-            # reset the Turtlebot odometry
-            reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
-            reset.publish(Empty())
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 
@@ -182,4 +183,4 @@ if __name__ == "__main__":
             Tester.shutdown(self)
         
 
-    NavigationTest()
+    NavigationTest().run()

--- a/navigation.py
+++ b/navigation.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
             # self.testLine(1)
             # reset the Turtlebot odometry
             reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
-            reset.publish(Empty)
+            reset.publish(Empty())
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 

--- a/navigation.py
+++ b/navigation.py
@@ -37,13 +37,13 @@ class Navigation():
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
     
         # set up the odometry reset publisher (publishing Empty messages here will reset odom)
-        self.reset_odom = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        self.reset_odom = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=1)
+        self.reset_odom.publish(Empty())
         
-        # reset odometry
-        # these messages take a few iterations to get through
-        timer = time()
-        while time() - timer < 0.25 or self.p is None:
-            self.reset_odom.publish(Empty())
+#        # reset odometry (these messages take a few iterations to get through)
+#        timer = time()
+#        while time() - timer < 0.25 or self.p is None:
+#            self.reset_odom.publish(Empty())
 
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """

--- a/navigation.py
+++ b/navigation.py
@@ -32,7 +32,6 @@ class Navigation():
         # reset Turtlebot odometry information on launch
         reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
         reset.publish(Empty())
-        rospy.sleep(1)
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = Point(0,0,0)

--- a/navigation.py
+++ b/navigation.py
@@ -104,9 +104,9 @@ if __name__ == "__main__":
 
         def main(self):
             """ The test currently being run. """
-            self.testCCsquare(.5)
+            #self.testCCsquare(.5)
             # self.testCsquare(.5)
-            # self.testLine(1)
+            self.testLine(1)
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 

--- a/navigation.py
+++ b/navigation.py
@@ -38,15 +38,11 @@ class Navigation():
     
         # set up the odometry reset publisher (publishing Empty messages here will reset odom)
         self.reset_odom = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=1)
-        self.reset_odom.publish(Empty())
-    
-        while self.p is None:
-            pass
         
-#        # reset odometry (these messages take a few iterations to get through)
-#        timer = time()
-#        while time() - timer < 0.25 or self.p is None:
-#            self.reset_odom.publish(Empty())
+        # reset odometry (these messages take a few iterations to get through)
+        timer = time()
+        while time() - timer < 0.1 or self.p is None:
+            self.reset_odom.publish(Empty())
 
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """

--- a/navigation.py
+++ b/navigation.py
@@ -32,11 +32,11 @@ class Navigation():
         # reset Turtlebot odometry information on launch
         reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
         reset.publish(Empty())
-        rospy.sleep(1)
+        rospy.sleep(2)
 
         # subscibe to the robot_pose_ekf odometry information
-        self.p = None
-        self.q = None
+        self.p = Point(0,0,0)
+        self.q = Quaternion(0,0,0,1)
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
 
     def _ekfCallback(self, data):

--- a/navigation.py
+++ b/navigation.py
@@ -36,7 +36,7 @@ class Navigation():
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
     
         # reset Turtlebot odometry information on launch
-        while self.p is None:
+        while not rospy.is_shutdown():
             reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
             reset.publish(Empty())
             rate.sleep()

--- a/navigation.py
+++ b/navigation.py
@@ -106,8 +106,12 @@ if __name__ == "__main__":
         def main(self):
             """ The test currently being run. """
             #self.testCCsquare(.5)
-            self.testCsquare(.5)
+            #self.testCsquare(.5)
             #self.testLine(1)
+            
+            # reset Turtlebot odometry information on launch
+            reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+            reset.publish(Empty())
         
         def gotToPos(self, name, x, y):
             """ Default behavior for testing goToPosition. 

--- a/navigation.py
+++ b/navigation.py
@@ -36,11 +36,14 @@ class Navigation():
         self.angle = 0
         rospy.Subscriber('/robot_pose_ekf/odom_combined', PoseWithCovarianceStamped, self._ekfCallback)
     
-        # reset Turtlebot odometry information on launch
-        reset = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        # set up the odometry reset publisher (publishing Empty messages here will reset odom)
+        self.reset_odom = rospy.Publisher('/mobile_base/commands/reset_odometry', Empty, queue_size=10)
+        
+        # reset odometry
+        # these messages take a few iterations to get through
         timer = time()
-        while time() - timer < 1 or self.p is None:
-            reset.publish(Empty())
+        while time() - timer < 0.25 or self.p is None:
+            self.reset_odom.publish(Empty())
 
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """

--- a/safe_motion.py
+++ b/safe_motion.py
@@ -133,10 +133,10 @@ if __name__ == "__main__":
         """ Run unit test for the motion class. """
         
         def __init__(self):
+            Tester.__init__(self, "SafeMotion")
+            
             # set up basic sensing
             self.motion = SafeMotion(safety_level=1)
-            
-            Tester.__init__(self, "SafeMotion")
 
         def main(self):
             # running walk here should behave like wander in the motion module test
@@ -145,4 +145,4 @@ if __name__ == "__main__":
         def shutdown(self):
             self.motion.shutdown(self.rate)
 
-    SafeMotionTest()
+    SafeMotionTest().run()

--- a/sensors.py
+++ b/sensors.py
@@ -100,10 +100,10 @@ if __name__ == "__main__":
     class SensorsTest(Tester):
         """ Behavioral tests for ObstacleDectection. """
         def __init__(self):
-            self.sensors = Sensors()
             Tester.__init__(self, "Sensors")
+            self.sensors = Sensors()
 
         def main(self):
             self.rate.sleep()
 
-    SensorsTest()
+    SensorsTest().run()

--- a/tester.py
+++ b/tester.py
@@ -20,7 +20,7 @@ class Tester():
         rate (rospy.Rate): Used to control the refresh rate of robot control loops.
         
     Note: When inheriting from the Tester class, its initialization sequence should be
-        the last thing to run in the inherting class's __init__ function.
+        the first thing to run in the inherting class's __init__ function.
     """
     def __init__(self, name):
         # set module name
@@ -38,11 +38,6 @@ class Tester():
         # set up test node logger
         self.logger = Logger(self.__name__)
         self.logger.info("hello world")
-    
-        # run the main control loop
-        while not rospy.is_shutdown():
-            self.main()
-            self.rate.sleep()
 
     def main(self):
         """ The main control loop.
@@ -50,6 +45,16 @@ class Tester():
         Note: This function must be overriden in the subclasses.
         """
         self.signal_shutdown("The main function in the Tester class must be overriden!")
+    
+    def run(self):
+        """ Actually run the robot tests, etc.
+        
+        Note: This function should not be overridden!
+        """
+        # run the main control loop
+        while not rospy.is_shutdown():
+            self.main()
+            self.rate.sleep()
 
     def shutdown(self):
         """ Stop all robot operations. 

--- a/tester.py
+++ b/tester.py
@@ -26,8 +26,9 @@ class Tester():
         # set module name
         self.__name__ = str(name) + "Tester"
         
-        # initialize test node
+        # initialize test node (and give it time to come online)
         rospy.init_node(self.__name__, anonymous = False)
+        rospy.sleep(1)
         
         # set up ctrl-C shutdown behavior
         rospy.on_shutdown(self.shutdown)

--- a/tester.py
+++ b/tester.py
@@ -26,9 +26,8 @@ class Tester():
         # set module name
         self.__name__ = str(name) + "Tester"
         
-        # initialize test node (and give it time to come online)
+        # initialize test node
         rospy.init_node(self.__name__, anonymous = False)
-        rospy.sleep(1)
         
         # set up ctrl-C shutdown behavior
         rospy.on_shutdown(self.shutdown)


### PR DESCRIPTION
Prevent error accumulation from when someone leave the package running by zeroing out the turtlebot's internal odometry data when the module launches. Required change to the structure of the Test base class so that the Tester class's initialization step could be the first thing to run. Now, to run Tester classes, you need to run the run() function to actually enter the main loop.