### PR TITLE
Added localization

### DIFF
--- a/launch/ar_tags.launch.xml
+++ b/launch/ar_tags.launch.xml
@@ -1,0 +1,10 @@
+<launch>
+    <arg name="marker_size"          default="3.0" />
+    <arg name="max_new_marker_error" default="0.05" />
+    <arg name="max_track_error"      default="0.05" />
+    <arg name="cam_image_topic"      default="/camera/depth_registered/points" />
+    <arg name="cam_info_topic"       default="/camera/rgb/camera_info" />
+    <arg name="output_frame"         default="/camera_rgb_optical_frame" />
+
+    <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkers" respawn="false" output="screen" args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error) $(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
+</launch>

--- a/localization.py
+++ b/localization.py
@@ -6,7 +6,7 @@ from ar_track_alvar_msgs.msg import AlvarMarkers
 from logger import Logger
 
 class Localization():
-    def __init__(self, tag_dict):
+    def __init__(self):
         
         # listen to the raw AprilTag data
         self.tags = None

--- a/localization.py
+++ b/localization.py
@@ -1,16 +1,31 @@
+""" Global localization.
+    
+Author:
+    Annaleah Ernst
+"""
 import rospy
 import tf
 
 from ar_track_alvar_msgs.msg import AlvarMarkers
+from geometry_msgs.msg import PoseStamped
 
 from logger import Logger
 
 class Localization():
+    """ Handle landmark detection and global localization.
+    
+    Attributes:
+        tags (geometry_msgs.msg.PoseStamped dict): A dict of all the AprilTags currently in view.
+    """
     def __init__(self):
+        self._logger = Logger("Localization")
         
         # listen to the raw AprilTag data
-        self.tags = None
+        self.tags = {}
         rospy.Subscriber('/ar_pose_marker', AlvarMarkers, self._tagCallback, queue_size=1)
+    
+        # listen for frame transformations
+        self._tf_listener = tf.TransformListener()
 
     def _tagCallback(self, data):
         """ Extract raw tag data from the ar_pose_marker topic.
@@ -18,9 +33,19 @@ class Localization():
         Note: Tag data comes in the camera frame, not the map frame.
         """
         if data.markers:
-            self.tags = data.markers
+            self.tags = {marker.id : PoseStamped(marker.pose.pose, marker.header) for marker in data.markers}
+            self._getRelativePos()
         else:
-            self.tags = None
+            self.tags = {}
+
+    def _getRelativePos(self):
+        """ Attempt a transformation. """
+        for id, tag in self.tags:
+            try:
+                self._logger(self._tf_listener.transformPose('/base_footprint',  tag))
+        
+            except Exception as e:
+                self._logger.error(e)
 
 if __name__ == "__main__":
     from tester import Tester

--- a/localization.py
+++ b/localization.py
@@ -40,11 +40,10 @@ class Localization():
 
     def _getRelativePos(self):
         """ Attempt a transformation. """
-        print self.tags
         for id in self.tags:
             try:
                 self._logger.info(self._tf_listener.transformPose('/base_footprint',  self.tags[id]))
-        
+                self._logger.info(self._tf_listener.transformPose('/odom',  self.tags[id]))
             except Exception as e:
                 self._logger.error(e)
 

--- a/localization.py
+++ b/localization.py
@@ -40,6 +40,7 @@ class Localization():
 
     def _getRelativePos(self):
         """ Attempt a transformation. """
+        print self.tags
         for id, tag in self.tags:
             try:
                 self._logger(self._tf_listener.transformPose('/base_footprint',  tag))

--- a/localization.py
+++ b/localization.py
@@ -1,0 +1,37 @@
+import rospy
+import tf
+
+from ar_track_alvar_msgs.msg import AlvarMarkers
+
+from logger import Logger
+
+class Localization():
+    def __init__(self, tag_dict):
+        
+        # listen to the raw AprilTag data
+        self.tags = None
+        rospy.Subscriber('/ar_pose_marker', AlvarMarkers, self._tagCallback, queue_size=1)
+
+    def _tagCallback(self, data):
+        """ Extract raw tag data from the ar_pose_marker topic.
+        
+        Note: Tag data comes in the camera frame, not the map frame.
+        """
+        if data.markers:
+            self.tags = data.markers
+        else:
+            self.tags = None
+
+if __name__ == "__main__":
+    from tester import Tester
+
+    class LocalizationTest(Tester):
+        """ Run localization tests. """
+        def __init__(self):
+            Tester.__init__(self, "Localization")
+            
+            # set up localization
+            self.localization = Localization()
+
+        def main(self):
+            self.logger.info(self.localization.tags)

--- a/localization.py
+++ b/localization.py
@@ -33,7 +33,7 @@ class Localization():
         Note: Tag data comes in the camera frame, not the map frame.
         """
         if data.markers:
-            self.tags = {marker.id : PoseStamped(marker.pose.pose, marker.header) for marker in data.markers}
+            self.tags = {marker.id : PoseStamped(marker.header, marker.pose.pose) for marker in data.markers}
             self._getRelativePos()
         else:
             self.tags = {}

--- a/localization.py
+++ b/localization.py
@@ -35,3 +35,5 @@ if __name__ == "__main__":
 
         def main(self):
             self.logger.info(self.localization.tags)
+
+    LocalizationTest().run()

--- a/localization.py
+++ b/localization.py
@@ -16,6 +16,7 @@ class Localization():
     
     Attributes:
         tags (geometry_msgs.msg.PoseStamped dict): A dict of all the AprilTags currently in view.
+            Note: in the /camera_rgb_optical_frame.
     """
     def __init__(self):
         self._logger = Logger("Localization")
@@ -34,12 +35,12 @@ class Localization():
         """
         if data.markers:
             self.tags = {marker.id : PoseStamped(marker.header, marker.pose.pose) for marker in data.markers}
-            self._getRelativePos()
+            self._transformPos()
         else:
             self.tags = {}
 
-    def _getRelativePos(self):
-        """ Attempt a transformation. """
+    def _transformPos(self):
+        """ Attempt a frame transformation. """
         for id in self.tags:
             try:
                 self._logger.info(self._tf_listener.transformPose('/base_footprint',  self.tags[id]))

--- a/localization.py
+++ b/localization.py
@@ -41,9 +41,9 @@ class Localization():
     def _getRelativePos(self):
         """ Attempt a transformation. """
         print self.tags
-        for id, tag in self.tags:
+        for id in self.tags:
             try:
-                self._logger(self._tf_listener.transformPose('/base_footprint',  tag))
+                self._logger(self._tf_listener.transformPose('/base_footprint',  self.tags[id]))
         
             except Exception as e:
                 self._logger.error(e)

--- a/localization.py
+++ b/localization.py
@@ -59,6 +59,6 @@ if __name__ == "__main__":
             self.localization = Localization()
 
         def main(self):
-            self.logger.info(self.localization.tags)
+            pass
 
     LocalizationTest().run()

--- a/localization.py
+++ b/localization.py
@@ -43,7 +43,7 @@ class Localization():
         print self.tags
         for id in self.tags:
             try:
-                self._logger(self._tf_listener.transformPose('/base_footprint',  self.tags[id]))
+                self._logger.info(self._tf_listener.transformPose('/base_footprint',  self.tags[id]))
         
             except Exception as e:
                 self._logger.error(e)


### PR DESCRIPTION
Created infrastructure for AprilTag localization. Currently just in the beta phase. Includes raw april tag data and transformations between coordinate frames (which are supplied via the tf module). The turtlebot base itself publishes many of these transformations (via minimal.launch). 
Actually understanding how these work should be a HUGE help in actually implementing localization, since it essentially eliminates all the nasty math.