### PR TITLE
Separately transform positions and orientations

### DIFF
--- a/localization.py
+++ b/localization.py
@@ -44,7 +44,7 @@ class Localization():
                 self.tags[marker.id] = PoseStamped(marker.header, marker.pose.pose)
                 
                 # set the frame of the data
-                #self.tags[marker.id].header.frame_id = '/ar_marker_' + str(marker.id)
+                self.tags[marker.id].header.frame_id = '/ar_marker_' + str(marker.id)
                 
                 # set the time to show that we only care about the most recent available transform
                 self.tags[marker.id].header.stamp = rospy.Time(0)
@@ -102,8 +102,9 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            #self.logOrientation(self.localization.landmarks_relative)
-            self.logPosition(self.localization.tags)
+            self.logOrientation(self.localization.landmarks_relative)
+            self.logOrientation(self.localization.landmarks_odom)
+            #self.logPosition(self.localization.landmarks_relative)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -34,16 +34,16 @@ class Localization():
         self._tf_listener = tf.TransformListener()
     
     def _attemptLookup(self, transform_func, target_frame, object):
-    """ Attempt a coordinate frame transformation.
-    
-    Args:
-        transform_func (tf function): A transformation function from the tf module.
-        target_frame (string): The desired final coordinate frame.
-        object (PoseStamped, PointStamped, QuaternionStamped): A stamped object to be transformed.
+        """ Attempt a coordinate frame transformation.
         
-    Returns:
-        An object transformed into the correct frame if successful, None otherwise.
-    """
+        Args:
+            transform_func (tf function): A transformation function from the tf module.
+            target_frame (string): The desired final coordinate frame.
+            object (PoseStamped, PointStamped, QuaternionStamped): A stamped object to be transformed.
+            
+        Returns:
+            An object transformed into the correct frame if successful, None otherwise.
+        """
         try:
             # attempt transformation
             return transform_func(target_frame, object)

--- a/localization.py
+++ b/localization.py
@@ -115,7 +115,7 @@ class Localization():
             #   frame to get the correct position
             header.frame_id = '/camera_rgb_optical_frame'
             position = self._attemptLookup(self._tf_listener.transformPoint, \
-                         target_frame, PoseStamped(header, self.tags[id].pose.position))
+                         target_frame, PointStamped(header, self.tags[id].pose.position))
                          
             # make sure the look-up succeeded
             if position is None:

--- a/localization.py
+++ b/localization.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         def main(self):
             """ Run main tests. """
             #self.logOrientation(self.localization.landmarks_relative)
-            self.logPosition(self.localization.landmarks_relative)
+            self.logPosition(self.localization.tags)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -61,7 +61,7 @@ class Localization():
         """
         transformed = {}
         for id in self.tags:
-            # copy the header from the current tag
+            # get the header from the current tag
             header = self.tags[id].header
             
             # set the time to show that we only care about the most recent available transform
@@ -77,8 +77,8 @@ class Localization():
                 self._logger.error(e)
                 continue
                 
-            # incoming position data is relative to the rgb camera frame, so we just create a PointStamped with the
-            #   correct header and tag position
+            # incoming position data is relative to the rgb camera frame, so we reset the header to the optical
+            #   frame to get the correct position
             header.frame_id = '/camera_rgb_optical_frame'
             try:
                 position = self._tf_listener.transformPoint(target_frame, PointStamped(header, self.tags[id].pose.position))

--- a/localization.py
+++ b/localization.py
@@ -65,7 +65,7 @@ class Localization():
             header = self.tags[id].header
             
             # set the time to show that we only care about the most recent available transform
-            self.tags[marker.id].header.stamp = rospy.Time(0)
+            self.tags[id].header.stamp = rospy.Time(0)
             
             # incoming position data is relative to the rgb camera frame (which is also the listed frame on incoming
             #   data), so we just create a PointStamped with the current header and tag position

--- a/localization.py
+++ b/localization.py
@@ -37,7 +37,7 @@ class Localization():
         """ Attempt a coordinate frame transformation.
         
         Args:
-            transform_func (tf function): A transformation function from the tf module.
+            transform_func (tf.TransformListener() function): A transformation function from the tf module.
             target_frame (string): The desired final coordinate frame.
             object (PoseStamped, PointStamped, QuaternionStamped): A stamped object to be transformed.
             
@@ -137,6 +137,9 @@ if __name__ == "__main__":
             
             # set up localization
             self.localization = Localization()
+        
+            # slow down refreshing just because logging is easier to parse
+            self.rate=rospy.rate(10)
 
         def main(self):
             """ Run main tests. """

--- a/localization.py
+++ b/localization.py
@@ -115,7 +115,7 @@ class Localization():
             #   frame to get the correct position
             header.frame_id = '/camera_rgb_optical_frame'
             position = self._attemptLookup(self._tf_listener.transformPoint, \
-                         target_frame, QuaternionStamped(header, self.tags[id].pose.position))
+                         target_frame, PoseStamped(header, self.tags[id].pose.position))
                          
             # make sure the look-up succeeded
             if position is None:

--- a/localization.py
+++ b/localization.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
             self.logPosition(self.localization.landmarks_relative)
             self.logger.info("odom")
             self.logOrientation(self.localization.landmarks_odom)
-            self.logPosition(self.localization.landmarks_relative)
+            self.logPosition(self.localization.landmarks_odom)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -36,7 +36,7 @@ class Localization():
     def _tagCallback(self, data):
         """ Extract raw tag data from the ar_pose_marker topic.
         
-        Note: Raw tag data comes in the camera frame, not the map frame.
+        Note: Raw tag data comes in the /ar_marker_<id> frame frame, not the map frame.
         """
         if data.markers:
             # convert marker data into PoseStamped
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         def main(self):
             """ Run main tests. """
             #self.logOrientation(self.localization.landmarks_relative)
-            self.logPosition(self.localization.landmarks_odom)
+            self.logPosition(self.localization.landmarks_relative)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -54,8 +54,7 @@ class Localization():
             
         except tf.LookupException as e:
             # the transformations aren't being published
-            self._logger.error(e)
-            self._logger.error("Is the mobile base powered on? Has the Turtlebot been brought online?")
+            self._logger.error(str(e) + " Is the mobile base powered on? Has the Turtlebot been brought online?")
         
         except Exception as e:
             # something else went wrong

--- a/localization.py
+++ b/localization.py
@@ -87,7 +87,7 @@ class Localization():
                 continue
             
             # if we made it this far, then we can add our pose data to our dictionary!
-            transformed[id] = PoseStamped(position.header, Pose(position.position, orientation.orientation))
+            transformed[id] = PoseStamped(position.header, Pose(position.point, orientation.quaternion))
             
         return transformed
 

--- a/localization.py
+++ b/localization.py
@@ -54,7 +54,7 @@ class Localization():
             
         except tf.LookupException as e:
             # the transformations aren't being published
-            self._logger.error(str(e) + " Is the mobile base powered on? Has the Turtlebot been brought online?")
+            self._logger.error(str(e) + "Is the mobile base powered on? Has the Turtlebot been brought online?")
         
         except Exception as e:
             # something else went wrong

--- a/localization.py
+++ b/localization.py
@@ -78,7 +78,7 @@ class Localization():
             
             # however, orientation data starts in the ar_marker_<id> frame; we need to switch the header frame for
             #   the next transformation to reflect this
-            header.frame_id = '/ar_marker_' + str(marker.id)
+            header.frame_id = '/ar_marker_' + str(id)
             try:
                 orientation = self._tf_listener.transformQuaternion(target_frame, QuaternionStamped(header, self.tags[id].pose.orientation))
             except Exception as e:

--- a/localization.py
+++ b/localization.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
             self.localization = Localization()
         
             # slow down refreshing just because logging is easier to parse
-            self.rate=rospy.rate(10)
+            self.rate = rospy.Rate(10)
 
         def main(self):
             """ Run main tests. """

--- a/localization.py
+++ b/localization.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            self.logOrientation(self.localization.landmarks_odom)
+            self.logOrientation(self.localization.landmarks_relative)
             #self.logPosition(self.localization.landmarks_odom)
             
         def logPosition(self, incoming_landmarks):

--- a/localization.py
+++ b/localization.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            self.logOrientation(self.localization.landmarks_relative)
+            self.logOrientation(self.localization.landmarks_odom)
             #self.logPosition(self.localization.landmarks_odom)
             
         def logPosition(self, incoming_landmarks):

--- a/localization.py
+++ b/localization.py
@@ -44,7 +44,7 @@ class Localization():
                 self.tags[marker.id] = PoseStamped(marker.header, marker.pose.pose)
                 
                 # set the frame of the data
-                self.tags[marker.id].header.frame_id = '/ar_marker_' + str(marker.id)
+                #self.tags[marker.id].header.frame_id = '/ar_marker_' + str(marker.id)
                 
                 # set the time to show that we only care about the most recent available transform
                 self.tags[marker.id].header.stamp = rospy.Time(0)

--- a/localization.py
+++ b/localization.py
@@ -102,8 +102,8 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            #self.logOrientation(self.localization.landmarks_relative)
-            self.logPosition(self.localization.landmarks_odom)
+            self.logOrientation(self.localization.landmarks_relative)
+            #self.logPosition(self.localization.landmarks_odom)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         def main(self):
             """ Run main tests. """
             #self.logOrientation(self.localization.landmarks_relative)
-            self.logPosition(self.localization.landmarks_relative)
+            self.logPosition(self.localization.landmarks_odom)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -87,7 +87,7 @@ class Localization():
                 continue
             
             # if we made it this far, then we can add our pose data to our dictionary!
-            transformed[id] = PoseStamped(position.header, Pose(position, orientation))
+            transformed[id] = PoseStamped(position.header, Pose(position.position, orientation.orientation))
             
         return transformed
 

--- a/localization.py
+++ b/localization.py
@@ -102,8 +102,8 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            self.logOrientation(self.localization.landmarks_relative)
-            #self.logPosition(self.localization.landmarks_odom)
+            #self.logOrientation(self.localization.landmarks_relative)
+            self.logPosition(self.localization.landmarks_relative)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -79,7 +79,8 @@ class Localization():
             
             except Exception as e:
                 # something went wrong with the coordinate transform, so we should move along
-                self._logger.error(e)
+                #self._logger.error(e)
+                raise(e)
                 continue
                 
             # incoming position data is relative to the rgb camera frame, so we reset the header to the optical

--- a/localization.py
+++ b/localization.py
@@ -102,9 +102,12 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
+            self.logger.info("orientation")
             self.logOrientation(self.localization.landmarks_relative)
+            self.logPosition(self.localization.landmarks_relative)
+            self.logger.info("odom")
             self.logOrientation(self.localization.landmarks_odom)
-            #self.logPosition(self.localization.landmarks_relative)
+            self.logPosition(self.localization.landmarks_relative)
             
         def logPosition(self, incoming_landmarks):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -67,20 +67,21 @@ class Localization():
             # set the time to show that we only care about the most recent available transform
             self.tags[id].header.stamp = rospy.Time(0)
             
-            # incoming position data is relative to the rgb camera frame (which is also the listed frame on incoming
-            #   data), so we just create a PointStamped with the current header and tag position
-            try:
-                position = self._tf_listener.transformPoint(target_frame, PointStamped(header, self.tags[id].pose.position))
-            except Exception as e:
-                # something went wrong with the coordinate transform, so we should move along
-                self._logger.error(e)
-                continue
-            
-            # however, orientation data starts in the ar_marker_<id> frame; we need to switch the header frame for
+            # orientation data starts in the ar_marker_<id> frame; we need to switch the header frame for
             #   the next transformation to reflect this
             header.frame_id = '/ar_marker_' + str(id)
             try:
                 orientation = self._tf_listener.transformQuaternion(target_frame, QuaternionStamped(header, self.tags[id].pose.orientation))
+            except Exception as e:
+                # something went wrong with the coordinate transform, so we should move along
+                self._logger.error(e)
+                continue
+                
+            # incoming position data is relative to the rgb camera frame, so we just create a PointStamped with the
+            #   correct header and tag position
+            header.frame_id = '/camera_rgb_optical_frame'
+            try:
+                position = self._tf_listener.transformPoint(target_frame, PointStamped(header, self.tags[id].pose.position))
             except Exception as e:
                 # something went wrong with the coordinate transform, so we should move along
                 self._logger.error(e)

--- a/localization.py
+++ b/localization.py
@@ -80,7 +80,7 @@ class Localization():
             #   the next transformation to reflect this
             header.frame_id = '/ar_marker_' + str(marker.id)
             try:
-                orientation = self._tf_listener.transformPoint(target_frame, QuaternionStamped(header, self.tags[id].pose.orientation))
+                orientation = self._tf_listener.transformQuaternion(target_frame, QuaternionStamped(header, self.tags[id].pose.orientation))
             except Exception as e:
                 # something went wrong with the coordinate transform, so we should move along
                 self._logger.error(e)


### PR DESCRIPTION
The positions of the ar_tags are relative to the /camera_rgb_optical_frame, but their orientations are relative to their special ar_markers<id> frame. By performing separate transformations, we are able to accurately obtain information for both of these components, rather than being forced to have almost useless data on one or the other.