### PR TITLE
Add landmark localization

### DIFF
--- a/localization.py
+++ b/localization.py
@@ -102,7 +102,7 @@ class Localization():
         # Note: in the following section, names of angles correspond to symbols in graph
         #   <TODO include graph number>
         # get the angle between the ARtag's x-axis and the map's x-axis
-        alpha = map.angle
+        alpha = - map.angle
         
         # get the angle between the ARtag's x-axis and the robot's x-axis (between 0 and -pi)
         q = closest.orientation

--- a/localization.py
+++ b/localization.py
@@ -119,7 +119,7 @@ class Localization():
         y = r * sin(theta) + map.pose.position.y
         
         # plug this into an estimated pose
-        q = tf.transformations.quaternion_from_euler([0,0,theta])
+        q = tf.transformations.quaternion_from_euler(0,0,theta)
         self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
         self._logger.info("POSE AND ANGLE")
         self._logger.info(self.estimated_pose)

--- a/localization.py
+++ b/localization.py
@@ -106,7 +106,7 @@ class Localization():
         
         # get the angle between the ARtag's x-axis and the robot's x-axis (between 0 and -pi)
         q = closest.orientation
-        beta = - tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
+        beta = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         
         # get the angle between the robot's x-axis and the vector from the robot base to the tag
         gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0]) / r)
@@ -135,6 +135,7 @@ class Localization():
         self._logger.debug(delta, var_name = "delta")
         self._logger.debug(theta, var_name = "theta")
         self._logger.debug(r, var_name = "radius")
+        
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """
@@ -150,6 +151,10 @@ class Localization():
             self.tags = {}
             self.tags_base = {}
             self.tags_odom = {}
+
+        for id in self.tags_odom:
+            q = self.tags_odom[id].pose.orientation
+            self._logger.debug(tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w][-1], var_name = "odom_orient")
 
     def _transformTags(self, target_frame):
         """ Convert all of the visible tags to target frame.

--- a/localization.py
+++ b/localization.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
             # set up localization (including map)
             landmarks = {0, 1}
             landmark_positions = {0:(0,0), 1:(1,1)}
-            landmark_orientations = {0:pi/2, 1:pi/2}
+            landmark_orientations = {0:-pi/2, 1:pi/2}
             self.floorplan = FloorPlan({},{},{},landmarks, landmark_positions, landmark_orientations)
             self.localization = Localization(self.floorplan.landmarks)
             

--- a/localization.py
+++ b/localization.py
@@ -106,7 +106,7 @@ class Localization():
         
         # get the angle between the ARtag's x-axis and the robot's x-axis (between 0 and -pi)
         q = closest.orientation
-        beta = tf.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
+        beta = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         
         # get the angle between the robot's x-axis and the vector from the robot base to the tag
         gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0])) / r
@@ -119,7 +119,7 @@ class Localization():
         y = r * sin(theta) + map.pose.position.y
         
         # plug this into an estimated pose
-        q = tf.quaternion_from_euler([0,0,theta])
+        q = tf.transformations.quaternion_from_euler([0,0,theta])
         self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
         self._logger.info("POSE AND ANGLE")
         self._logger.info(self.estimated_pose)

--- a/localization.py
+++ b/localization.py
@@ -76,23 +76,31 @@ class Localization():
         return None
         
     def _estimatePose(self):
-    
-        # attempt to get the closest landmark in out landmark dict
+        """ Estimate current position based on proximity to landmarks. """
+        
+        # attempt to get the id of the closest landmark
         try:
-            distance, closest_id = min(((self.tags_base[id].pose.position.x**2 + self.tags_base[id].pose.position.y**2, id) for id in self.tags_base if id in self.landmarks))
+            t = self.tags_base
+            
+            # compute the closest (viable) tag by looking for the smallest distance squared from the robot base
+            #   among tags that also appear in landmarks
+            dist2, closest_id = min((t[id].pose.position.x**2 + t[id].pose.position.y**2, id) for id in t if id in self.landmarks)
         
         # the argument to min was an empty list; we don't see any familiar landmarks
-        except TypeError as e:
+        except TypeError, ValueError as e:
             self.estimated_pose = None
             return
     
-        self._logger.info(closest_id)
+        self._logger.debug(closest_id)
         
+        # extract the closest tag and corresponding landmark
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
         
-        distance = sqrt(distance)
-
+        # compute the distance from the distance squared we got out of our min calculation and get angle
+        distance_to_tag = sqrt(dist2)
+        angle_with_tag = tf.transformations.euler_from_quaternion([q.x,q.y,q.z,q.w])[-1]
+        
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -79,7 +79,7 @@ class Localization():
         # attempt to get the closest landmark in out landmark dict
         try:
             closest_id, distance = min(((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2) for id in self.tags_base if id in self.landmarks),
-                            key = lambda i: )
+                            key = lambda (i, j): j)
         
         # the argument to min was an empty list; we don't see any familiar landmarks
         except TypeError as e:

--- a/localization.py
+++ b/localization.py
@@ -111,16 +111,21 @@ class Localization():
         # get the angle between the robot's x-axis and the vector from the robot base to the tag
         gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0]) / r )
 
-        # the sum of these angles is the angle between the map x-axis and the vector to the AR tag
-        theta = alpha + beta + gamma
+        # compute the angle between the x-axis in the robot frame and the x-axis in the map frame
+        delta = alpha + beta
+
+        # now compute the angle between the map x-axis and the vector to the AR tag
+        theta = delta + gamma
         
         # compute the robot position in the map frame
         x = map.pose.position.x + r * cos(theta)
         y = map.pose.position.y + r * sin(theta)
         
         # plug this into an estimated pose
-        q = tf.transformations.quaternion_from_euler(0,0,theta)
+        q = tf.transformations.quaternion_from_euler(0,0,delta)
         self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
+        
+        
         self._logger.info("POSE AND ANGLE")
         self._logger.info(closest_id)
         self._logger.info(self.estimated_pose)

--- a/localization.py
+++ b/localization.py
@@ -124,7 +124,10 @@ class Localization():
         self._logger.info("POSE AND ANGLE")
         self._logger.info(closest_id)
         self._logger.info(self.estimated_pose)
-        self._logger.info(theta / pi)
+        self._logger.debug(alpha, var_name = "alpha")
+        self._logger.debug(beta, var_name = "beta")
+        self._logger.debug(gamma, var_name = "gamma")
+        self._logger.debug(theta, var_name = "theta")
         self._logger.info(r)
 
     def _tagCallback(self, data):
@@ -208,7 +211,7 @@ if __name__ == "__main__":
             # set up localization (including map)
             landmarks = {0, 1}
             landmark_positions = {0:(0,0), 1:(1,1)}
-            landmark_orientations = {0:0, 1:pi/2}
+            landmark_orientations = {0:-pi/2, 1:pi/2}
             self.floorplan = FloorPlan({},{},{},landmarks, landmark_positions, landmark_orientations)
             self.localization = Localization(self.floorplan.landmarks)
             

--- a/localization.py
+++ b/localization.py
@@ -69,6 +69,18 @@ class Localization():
         
         # the transformation failed
         return None
+        
+    def _estimatePose(self):
+    
+        # attempt to get the closest landmark in out landmark dict
+        try:
+            closest = min(self.tags_relative[id] for id in self.tags_relative if id in self.landmarks,
+                        key = lambda p : p.pose.position.x**2 + p.pose.position.y**2)
+        
+        # the argument to min was an empty list; we don't see any familiar landmarks
+        except TypeError as e:
+            self.estimated_pose = None
+            return
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -86,6 +86,7 @@ class Localization():
             self.estimated_pose = None
             return
     
+        self._logger(closest_id)
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
 
@@ -98,6 +99,7 @@ class Localization():
             self.tags = {marker.id : PoseStamped(marker.header, marker.pose.pose) for marker in data.markers}
             self.tags_base = self._transformTags('/base_footprint')
             self.tags_odom = self._transformTags('/odom')
+            self._estimatePose()
         else:
             # we don't see any tags, so empty things out
             self.tags = {}

--- a/localization.py
+++ b/localization.py
@@ -78,7 +78,7 @@ class Localization():
     
         # attempt to get the closest landmark in out landmark dict
         try:
-            closest_id, distance = min((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2
+            closest_id, distance = min((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2 \
                                         for id in self.tags_base if id in self.landmarks),
                                         key = lambda i, j: j)
         

--- a/localization.py
+++ b/localization.py
@@ -106,10 +106,10 @@ class Localization():
         
         # get the angle between the ARtag's x-axis and the robot's x-axis (between 0 and -pi)
         q = closest.orientation
-        beta = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
+        beta = - tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         
         # get the angle between the robot's x-axis and the vector from the robot base to the tag
-        gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0]) / r )
+        gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0]) / r)
 
         # compute the angle between the x-axis in the robot frame and the x-axis in the map frame
         delta = alpha + beta

--- a/localization.py
+++ b/localization.py
@@ -114,8 +114,9 @@ class Localization():
         # the sum of these angles is the angle between the map x-axis and the vector to the AR tag
         theta = alpha + beta + gamma
         
-        x = cos(theta) + map.pose.position.x
-        y = sin(theta) + map.pose.position.y
+        # compute the robot position in the map frame
+        x = r * cos(theta) + map.pose.position.x
+        y = r * sin(theta) + map.pose.position.y
         
         # plug this into an estimated pose
         q = tf.quaternion_from_euler([0,0,theta])

--- a/localization.py
+++ b/localization.py
@@ -109,14 +109,14 @@ class Localization():
         beta = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         
         # get the angle between the robot's x-axis and the vector from the robot base to the tag
-        gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0])) / r
+        gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0]) / r )
 
         # the sum of these angles is the angle between the map x-axis and the vector to the AR tag
         theta = alpha + beta + gamma
         
         # compute the robot position in the map frame
-        x = map.pose.position.x - r * cos(theta)
-        y = map.pose.position.y - r * sin(theta)
+        x = map.pose.position.x + r * cos(theta)
+        y = map.pose.position.y + r * sin(theta)
         
         # plug this into an estimated pose
         q = tf.transformations.quaternion_from_euler(0,0,theta)

--- a/localization.py
+++ b/localization.py
@@ -152,10 +152,6 @@ class Localization():
             self.tags_base = {}
             self.tags_odom = {}
 
-        for id in self.tags_odom:
-            q = self.tags_odom[id].pose.orientation
-            self._logger.debug(tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w][-1], var_name = "odom_orient")
-
     def _transformTags(self, target_frame):
         """ Convert all of the visible tags to target frame.
         

--- a/localization.py
+++ b/localization.py
@@ -134,7 +134,7 @@ class Localization():
         self._logger.debug(gamma, var_name = "gamma")
         self._logger.debug(delta, var_name = "delta")
         self._logger.debug(theta, var_name = "theta")
-        self._logger.info(r)
+        self._logger.debug(r, var_name = "radius")
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -102,7 +102,7 @@ class Localization():
         # Note: in the following section, names of angles correspond to symbols in graph
         #   <TODO include graph number>
         # get the angle between the ARtag's x-axis and the map's x-axis
-        alpha = - map.angle
+        alpha = map.angle
         
         # get the angle between the ARtag's x-axis and the robot's x-axis (between 0 and -pi)
         q = closest.orientation

--- a/localization.py
+++ b/localization.py
@@ -87,6 +87,7 @@ class Localization():
             return
     
         self._logger.info(closest_id)
+        
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
 

--- a/localization.py
+++ b/localization.py
@@ -7,7 +7,7 @@ import rospy
 import tf
 
 from ar_track_alvar_msgs.msg import AlvarMarkers
-from geometry_msgs.msg import PointStamped, PoseStamped, Pose, QuaternionStamped
+from geometry_msgs.msg import PointStamped, PoseStamped, Pose, QuaternionStamped, Point
 from math import cos, sin, sqrt
 
 from logger import Logger

--- a/localization.py
+++ b/localization.py
@@ -119,7 +119,7 @@ class Localization():
         
         # compute the robot position in the map frame
         x = map.pose.position.x + r * cos(theta)
-        y = map.pose.position.y + r * sin(theta)
+        y = map.pose.position.y - r * sin(theta)
         
         # plug this into an estimated pose
         q = tf.transformations.quaternion_from_euler(0,0,delta)

--- a/localization.py
+++ b/localization.py
@@ -122,8 +122,9 @@ class Localization():
         q = tf.transformations.quaternion_from_euler(0,0,theta)
         self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
         self._logger.info("POSE AND ANGLE")
+        self._logger.info(closest_id)
         self._logger.info(self.estimated_pose)
-        self._logger.info(angle)
+        self._logger.info(theta)
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -115,7 +115,7 @@ class Localization():
         theta = alpha + beta + gamma
         
         # compute the robot position in the map frame
-        x = map.pose.position.x - r * cos(theta) +
+        x = map.pose.position.x - r * cos(theta)
         y = map.pose.position.y - r * sin(theta)
         
         # plug this into an estimated pose

--- a/localization.py
+++ b/localization.py
@@ -96,14 +96,7 @@ class Localization():
         map = self.landmarks[closest_id]
         
         # compute the distance from the distance squared we got out of our min calculation and get angle
-        q = closest.pose.orientation
-        distance_to_tag = sqrt(dist2)
-        angle_with_tag = tf.transformations.euler_from_quaternion([q.x,q.y,q.z,q.w])[-1]
-
-        x = distance_to_tag * cos(angle_with_tag + map.angle)
-        y = distance_to_tag * sin(angle_with_tag + map.angle)
-
-        print (Point(x,y,0))
+        # turns out there's a lot of weird math that's going to go into this...
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -119,7 +119,7 @@ class Localization():
         
         # compute the robot position in the map frame
         x = map.pose.position.x + r * cos(theta)
-        y = map.pose.position.y - r * sin(theta)
+        y = map.pose.position.y + r * sin(theta)
         
         # plug this into an estimated pose
         q = tf.transformations.quaternion_from_euler(0,0,delta)

--- a/localization.py
+++ b/localization.py
@@ -105,7 +105,7 @@ class Localization():
         alpha = map.angle
         
         # get the angle between the ARtag's x-axis and the robot's x-axis (between 0 and -pi)
-        q = closest.pose.orientation
+        q = closest.orientation
         beta = tf.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         
         # get the angle between the robot's x-axis and the vector from the robot base to the tag

--- a/localization.py
+++ b/localization.py
@@ -90,17 +90,20 @@ class Localization():
         except (TypeError, ValueError) as e:
             self.estimated_pose = None
             return
-    
-        self._logger.debug(closest_id)
         
         # extract the closest tag and corresponding landmark
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
         
         # compute the distance from the distance squared we got out of our min calculation and get angle
+        q = closest.pose.orientation
         distance_to_tag = sqrt(dist2)
         angle_with_tag = tf.transformations.euler_from_quaternion([q.x,q.y,q.z,q.w])[-1]
-        
+
+        x = distance_to_tag * cos(angle_with_tag + map.angle)
+        y = distance_to_tag * sin(angle_with_tag + map.angle)
+
+        print (Point(x,y,0))
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """
@@ -198,7 +201,7 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            self.logData()
+            pass
         
         def logData(self):
             """ Log CSV file and output data to screen. """

--- a/localization.py
+++ b/localization.py
@@ -87,7 +87,7 @@ class Localization():
             dist2, closest_id = min((t[id].pose.position.x**2 + t[id].pose.position.y**2, id) for id in t if id in self.landmarks)
         
         # the argument to min was an empty list; we don't see any familiar landmarks
-        except TypeError, ValueError as e:
+        except (TypeError, ValueError) as e:
             self.estimated_pose = None
             return
     

--- a/localization.py
+++ b/localization.py
@@ -78,8 +78,7 @@ class Localization():
     
         # attempt to get the closest landmark in out landmark dict
         try:
-            closest_id, distance = min(((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2) for id in self.tags_base if id in self.landmarks),
-                            key = lambda (i, j): j)
+            distance, closest_id = min(((self.tags_base[id].pose.position.x**2 + self.tags_base[id].pose.position.y**2, id) for id in self.tags_base if id in self.landmarks))
         
         # the argument to min was an empty list; we don't see any familiar landmarks
         except TypeError as e:

--- a/localization.py
+++ b/localization.py
@@ -86,7 +86,7 @@ class Localization():
             self.estimated_pose = None
             return
     
-        self._logger(closest_id)
+        self._logger.info(closest_id)
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
 

--- a/localization.py
+++ b/localization.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from ar_track_alvar_msgs.msg import AlvarMarkers
 from geometry_msgs.msg import PointStamped, PoseStamped, Pose, QuaternionStamped, Point, Quaternion
-from math import acos, cos, sin, sqrt
+from math import acos, cos, sin, sqrt, pi
 
 from logger import Logger
 
@@ -124,7 +124,7 @@ class Localization():
         self._logger.info("POSE AND ANGLE")
         self._logger.info(closest_id)
         self._logger.info(self.estimated_pose)
-        self._logger.info(theta)
+        self._logger.info(theta / pi)
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -8,6 +8,7 @@ import tf
 
 from ar_track_alvar_msgs.msg import AlvarMarkers
 from geometry_msgs.msg import PointStamped, PoseStamped, Pose, QuaternionStamped
+from math import cos, sin, sqrt
 
 from logger import Logger
 
@@ -90,7 +91,7 @@ class Localization():
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
         
-        distance = sqrt(self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2)
+        distance = sqrt(distance)
 
 
     def _tagCallback(self, data):

--- a/localization.py
+++ b/localization.py
@@ -78,8 +78,9 @@ class Localization():
     
         # attempt to get the closest landmark in out landmark dict
         try:
-            closest_id = min((id for id in self.tags_base if id in self.landmarks),
-                            key = lambda i: self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2)
+            closest_id, distance = min((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2
+                                        for id in self.tags_base if id in self.landmarks),
+                                        key = lambda i, j: j)
         
         # the argument to min was an empty list; we don't see any familiar landmarks
         except TypeError as e:
@@ -90,6 +91,8 @@ class Localization():
         
         closest = self.tags_base[closest_id]
         map = self.landmarks[closest_id]
+        
+        distance = sqrt(self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2)
 
 
     def _tagCallback(self, data):

--- a/localization.py
+++ b/localization.py
@@ -157,7 +157,7 @@ class Localization():
 if __name__ == "__main__":
     import numpy as np
     from tester import Tester
-    from math import degrees
+    from math import degrees, pi
     from copy import deepcopy
     from floorplan import FloorPlan
 

--- a/localization.py
+++ b/localization.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
             Tester.__init__(self, "Localization")
             
             # set up localization (including map)
-            landmarks = {0, 0}
+            landmarks = {0, 1}
             landmark_positions = {0:(0,0), 1:(1,1)}
             landmark_orientations = {0:0, 1:pi/2}
             self.floorplan = FloorPlan({},{},{},landmarks, landmark_positions, landmark_orientations)

--- a/localization.py
+++ b/localization.py
@@ -115,8 +115,8 @@ class Localization():
         theta = alpha + beta + gamma
         
         # compute the robot position in the map frame
-        x = r * cos(theta) + map.pose.position.x
-        y = r * sin(theta) + map.pose.position.y
+        x = map.pose.position.x - r * cos(theta) +
+        y = map.pose.position.y - r * sin(theta)
         
         # plug this into an estimated pose
         q = tf.transformations.quaternion_from_euler(0,0,theta)

--- a/localization.py
+++ b/localization.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
             # set up localization (including map)
             landmarks = {0, 1}
             landmark_positions = {0:(0,0), 1:(1,1)}
-            landmark_orientations = {0:-pi/2, 1:pi/2}
+            landmark_orientations = {0:pi/2, 1:pi/2}
             self.floorplan = FloorPlan({},{},{},landmarks, landmark_positions, landmark_orientations)
             self.localization = Localization(self.floorplan.landmarks)
             

--- a/localization.py
+++ b/localization.py
@@ -78,9 +78,8 @@ class Localization():
     
         # attempt to get the closest landmark in out landmark dict
         try:
-            closest_id, distance = min((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2 \
-                                        for id in self.tags_base if id in self.landmarks),
-                                        key = lambda i, j: j)
+            closest_id, distance = min(((id, self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2) for id in self.tags_base if id in self.landmarks),
+                            key = lambda i: )
         
         # the argument to min was an empty list; we don't see any familiar landmarks
         except TypeError as e:

--- a/localization.py
+++ b/localization.py
@@ -78,13 +78,17 @@ class Localization():
     
         # attempt to get the closest landmark in out landmark dict
         try:
-            closest = min(id for id in self.tags_base if id in self.landmarks,
-                        key = lambda i : self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2)
+            closest_id = min((id for id in self.tags_base if id in self.landmarks),
+                            key = lambda i: self.tags_base[i].pose.position.x**2 + self.tags_base[i].pose.position.y**2)
         
         # the argument to min was an empty list; we don't see any familiar landmarks
         except TypeError as e:
             self.estimated_pose = None
             return
+    
+        closest = self.tags_base[closest_id]
+        map = self.landmarks[closest_id]
+
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from ar_track_alvar_msgs.msg import AlvarMarkers
 from geometry_msgs.msg import PointStamped, PoseStamped, Pose, QuaternionStamped, Point, Quaternion
-from math import acos, cos, sin, sqrt, pi
+from math import atan2, cos, sin, sqrt, pi
 
 from logger import Logger
 
@@ -109,17 +109,17 @@ class Localization():
         beta = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         
         # get the angle between the robot's x-axis and the vector from the robot base to the tag
-        gamma = acos(np.dot([closest.position.x, closest.position.y], [1, 0]) / r)
+        gamma = atan2(closest.position.y, closest.position.x)
 
         # compute the angle between the x-axis in the robot frame and the x-axis in the map frame
-        delta = alpha + beta
+        delta = alpha - beta
 
         # now compute the angle between the map x-axis and the vector to the AR tag
         theta = delta + gamma
         
         # compute the robot position in the map frame
-        x = map.pose.position.x + r * cos(theta)
-        y = map.pose.position.y + r * sin(theta)
+        x = map.pose.position.x - r * cos(theta)
+        y = map.pose.position.y - r * sin(theta)
         
         # plug this into an estimated pose
         q = tf.transformations.quaternion_from_euler(0,0,delta)
@@ -163,7 +163,7 @@ class Localization():
                 of the visible AprilTags that were successfully transformed.
                 
         Note: 
-            Raw tag orientation data comes in the /ar_marker_<id> frame, and its position data come in the
+            Raw tag orientation data comes in the /ar_marker_<id> frame, and its position data comes in the
                 /camera_rgb_optical_frame, so our transformations must reflect this.
             Also note that this is the scary function...
         """

--- a/localization.py
+++ b/localization.py
@@ -132,6 +132,7 @@ class Localization():
         self._logger.debug(alpha, var_name = "alpha")
         self._logger.debug(beta, var_name = "beta")
         self._logger.debug(gamma, var_name = "gamma")
+        self._logger.debug(delta, var_name = "delta")
         self._logger.debug(theta, var_name = "theta")
         self._logger.info(r)
 

--- a/localization.py
+++ b/localization.py
@@ -125,6 +125,7 @@ class Localization():
         self._logger.info(closest_id)
         self._logger.info(self.estimated_pose)
         self._logger.info(theta / pi)
+        self._logger.info(r)
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """


### PR DESCRIPTION
Localize the robot using the relative position of the landmark with respect to the robot. Note that the field of view of the robot is -pi/2 to pi/2 and the field of view of the landmark is -pi to 0.

TODO: create transformation from map frame to odometry frame. Remove extraneous logging information.