### PR TITLE
Massive Localization updates

### DIFF
--- a/localization.py
+++ b/localization.py
@@ -242,7 +242,7 @@ class Localization():
         roll, pitch, yaw = tf.transformations.euler_from_quaternion([q.x,q.y,q.z,q.w])
         return [p.x, p.y, p.z, q.x, q.y, q.z, q.w, roll, pitch, yaw]
 
-    def _csvLogAR(self, test_name, tags, tag_type, folder)
+    def _csvLogAR(self, test_name, tags, tag_type, folder):
         """ Log information on all tags currently in view. """
     
         tags = deepcopy(tags)

--- a/localization.py
+++ b/localization.py
@@ -37,7 +37,7 @@ class Localization():
         self.estimated_pose (geometry_msgs.msg.Pose or None): The estimated pose of the robot based 
             on the visible tags. None if no tags visible.
     """
-    _AR_FOV_LIMIT = 2.0 * pi / 15
+    _AR_FOV_LIMIT = pi / 6 #2.0 * pi / 15
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging

--- a/localization.py
+++ b/localization.py
@@ -302,7 +302,7 @@ if __name__ == "__main__":
 
         def main(self):
             """ Run main tests. """
-            self.localization.csvLogEstimated(self.test_name)
+            self.localization.csvLogEstimated(self.csvtestname)
         
         def screenLog(self, landmark, id):
             """ Nicely parse landmarks into easily logable data. """

--- a/localization.py
+++ b/localization.py
@@ -139,7 +139,7 @@ class Localization():
         x = map.pose.position.x - r * cos(theta)
         y = map.pose.position.y - r * sin(theta)
         
-        # make sure that we aren't getting insane localization data and are sampling at our reduced rate
+        # make sure that we aren't getting insane localization data
         if np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
             
             # plug this into an estimated pose in the map frame

--- a/localization.py
+++ b/localization.py
@@ -257,7 +257,7 @@ class Localization():
             # update the previous
             self._prev_csv[tag_type][id] = csv_tag
 
-    def csvLogEstimated(self, test_name, folder = "tests"):
+    def csvLogEstimated(self, test_name, folder = None):
         """ Log current position estimate if different from last logging. """
         
         if self.estimated_pose is None:
@@ -272,12 +272,12 @@ class Localization():
     
         self._prev_csv["estimated"] = csv_estimated
 
-    def csvLogRaw(self, test_name, folder = "tests"):
+    def csvLogRaw(self, test_name, folder = None):
         """ Log new raw tag data in separate files. """
         
         self._csvLogAR(test_name, self.tags, "raw", folder)
 
-    def csvLogRelative(self, test_name, folder = "tests"):
+    def csvLogRelative(self, test_name, folder = None):
         """ Log new position of AR tags relative to the robot base in separate files. """
 
         self._csvLogAR(test_name, self.tags_base, "relative", folder)

--- a/localization.py
+++ b/localization.py
@@ -122,7 +122,17 @@ class Localization():
     
     def transformAngle(self, angle, from_frame, to_frame):
         """ Transform an angle from the from frame to the to frame. """
-        return self.transform[to_frame + "_angle"] + angle - self._transform[from_frame + "_angle"]
+        
+        # compute transformation
+        transformed_angle = self.transform[to_frame + "_angle"] + angle - self._transform[from_frame + "_angle"]
+        
+        # wrap angle, if necessary
+        if transformed_angle > pi:
+            transformed_angle -= self._TWO_PI
+        elif transformed_angle < -pi:
+            transformed_angle += self._TWO_PI
+        
+        return transformed_angle
     
     def _setTransform(self):
         # attempt to get the id of the closest landmark

--- a/localization.py
+++ b/localization.py
@@ -113,7 +113,7 @@ class Localization():
         dy = position.y - self._transform[from_pos].y
         
         # the amount we've rotated since we've logged a transform point
-        delta = self._transform[from_frame + "_angle"] - self._transform[to_frame + "_angle"]
+        delta = self._transform[to_frame + "_angle"] - self._transform[from_frame + "_angle"] #self._transform[from_frame + "_angle"] - self._transform[to_frame + "_angle"]
     
         # now, add this movement back in to last transform point in the desired frame
         x = self._transform[to_pos].x + dx * cos(delta) - dy * sin(delta)

--- a/localization.py
+++ b/localization.py
@@ -39,7 +39,7 @@ class Localization():
             on the visible tags. None if no tags visible.
     """
     _AR_FOV_LIMIT = pi / 8  # radians
-    _AR_UPDATE_TIME = 0.0   # seconds
+    _AR_UPDATE_TIME = 0.25  # seconds
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging
@@ -141,7 +141,7 @@ class Localization():
         y = map.pose.position.y - r * sin(theta)
         
         # make sure that we aren't getting insane localization data and are sampling at our reduced rate
-        if (np.allclose([x, y, delta], self._prev_est, atol = 0.05, rtol = 0.05)
+        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05)
             and self._prev_update_time - time() > self._AR_UPDATE_TIME):
             
             # plug this into an estimated pose in the map frame

--- a/localization.py
+++ b/localization.py
@@ -37,7 +37,7 @@ class Localization():
         self.estimated_pose (geometry_msgs.msg.Pose or None): The estimated pose of the robot based 
             on the visible tags. None if no tags visible.
     """
-    _AR_FOV_LIMIT = pi / 8 #2.0 * pi / 15
+    _AR_FOV_LIMIT = pi / 8
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging
@@ -136,7 +136,7 @@ class Localization():
         y = map.pose.position.y - r * sin(theta)
         
         # make sure that we aren't getting insane localization data
-        if not np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
+        if not np.allclose([x, y, delta], self._prev_est, atol = 0.05, rtol = 0.05):
             self.estimated_pose = None
             self.estimated_angle = None
             

--- a/localization.py
+++ b/localization.py
@@ -141,14 +141,14 @@ class Localization():
         y = map.pose.position.y - r * sin(theta)
         
         # make sure that we aren't getting insane localization data and are sampling at our reduced rate
-        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05)):
-            #and self._prev_update_time - time() > self._AR_UPDATE_TIME):
+        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05)
+            and self._prev_update_time - time() > self._AR_UPDATE_TIME):
             
             # plug this into an estimated pose in the map frame
             q = tf.transformations.quaternion_from_euler(0,0,delta)
             self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
             self.estimated_angle = delta
-            self._prev_update_time = time()
+            self._prev_update_time += self._AR_UPDATE_TIME
 
         # update the previous so that we can continue annealing
         self._prev_est = [x, y, delta]

--- a/localization.py
+++ b/localization.py
@@ -239,7 +239,7 @@ class Localization():
         
             # log each tag in a separate folder
             fields, data = self._csvPose(tags[id].pose)
-            self._logger(test_name + "_" + tag_type + "_marker" + str(id), fields, data, folder = folder)
+            self._logger.csv(test_name + "_" + tag_type + "_marker" + str(id), fields, data, folder = folder)
 
     def csvLogEstimated(self, test_name, folder = "tests"):
         """ Log current position estimate. """

--- a/localization.py
+++ b/localization.py
@@ -43,7 +43,7 @@ class Localization():
         # set up logger and csv logging
         self._logger = Logger("Localization")
         self._csvFields = ["X", "Y", "Z", "qX", "qY", "qZ", "qW", "roll", "pitch", "yaw"]
-        self._prev_csv = {"estimated" = 0, "raw" = {}, "relative" = {}}
+        self._prev_csv = {"estimated": 0, "raw": {}, "relative": {}}
         
         # store raw tag data, data in the odom frame, and data in the base frame
         self.tags = {}

--- a/localization.py
+++ b/localization.py
@@ -140,7 +140,7 @@ class Localization():
         y = map.pose.position.y - r * sin(theta)
         
         # make sure that we aren't getting insane localization data and are sampling at our reduced rate
-        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
+        if np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
             
             # plug this into an estimated pose in the map frame
             q = tf.transformations.quaternion_from_euler(0,0,delta)

--- a/localization.py
+++ b/localization.py
@@ -99,7 +99,7 @@ class Localization():
         # the transformation failed
         return None
     
-    def transformPoint(self, point, from_frame, to_frame):
+    def transformPoint(self, position, from_frame, to_frame):
         """ Compute coordinate transformation.
         
         Args:

--- a/localization.py
+++ b/localization.py
@@ -263,9 +263,8 @@ class Localization():
         
         if self.estimated_pos is None:
             return
-        
-        fields, data = self._csvPose(self.estimated_pos)
-        self._logger.csv(test_name + "_estimated", fields, data, folder=folder)
+            
+        self._logger.csv(test_name + "_estimated", ["X", "Y", "yaw"], [self.estimated_pos.x, self.estimated_pos.y, self.estimated_angle], folder=folder)
 
     def csvLogRawTags(self, test_name, folder = "tests"):
         """ Log new raw tag data in separate files. """

--- a/localization.py
+++ b/localization.py
@@ -57,7 +57,6 @@ class Localization():
         
         # smooth data by selectively sampling
         self._prev_est = [0,0,0]
-        self._prev_update_time = float('inf')
     
         # listen for frame transformations
         self._tf_listener = tf.TransformListener()
@@ -145,20 +144,20 @@ class Localization():
         self.estimated_pos = Point(x,y,0)
         self.estimated_angle = delta
             
-#        # make sure that we aren't getting insane localization data
-#        if np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
-#            
-#            # plug this into an estimated pose in the map frame
-#            self.estimated_pos = Point(x,y,0)
-#            self.estimated_angle = delta
-#            
-#        # otherwise, we need to set our estimation to None
-#        else:
-#            self.estimated_pos = None
-#            self.estimated_angle = None
-#
-#        # update the previous so that we can continue annealing
-#        self._prev_est = [x, y, delta]
+        # make sure that we are getting reasonable
+        if np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
+            
+            # plug this into an estimated pose in the map frame
+            self.estimated_pos = Point(x,y,0)
+            self.estimated_angle = delta
+
+        # otherwise, we need to reset estimation
+        else:
+            self.estimated_pos = None
+            self.estimated_angle = None
+
+        # update the previous so that we can continue sanity checking
+        self._prev_est = [x, y, delta]
 
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """

--- a/localization.py
+++ b/localization.py
@@ -344,9 +344,9 @@ class Localization():
     def csvLogTransform(self, test_name, folder = "tests"):
         """ Log the transformation from the ekf frame to the map frame. """
                             
-        self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf"],
+        self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_odom", "Y_odom", "angle_odom"],
                     [self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"],
-                            self._transform["map_pos"].x, self._transform["map_pos"].y],
+                            self._transform["odom_pos"].x, self._transform["odom_pos"].y, self._transform["odom_angle"]],
                     folder = folder)
 
     def shutdown(self):

--- a/localization.py
+++ b/localization.py
@@ -38,7 +38,7 @@ class Localization():
         self.estimated_pose (geometry_msgs.msg.Pose or None): The estimated pose of the robot based 
             on the visible tags. None if no tags visible.
     """
-    _AR_FOV_LIMIT = pi / 8  # radians
+    _AR_FOV_LIMIT = 2.0 * pi / 15.0  # radians
     _AR_UPDATE_TIME = 0.25  # seconds
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):

--- a/localization.py
+++ b/localization.py
@@ -141,21 +141,25 @@ class Localization():
         x = map.pose.position.x - r * cos(theta)
         y = map.pose.position.y - r * sin(theta)
         
-        # make sure that we aren't getting insane localization data
-        if np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
+        # plug this into an estimated pose in the map frame
+        self.estimated_pos = Point(x,y,0)
+        self.estimated_angle = delta
             
-            # plug this into an estimated pose in the map frame
-            self.estimated_pos = Point(x,y,0)
-            self.estimated_angle = delta
-            
-        # otherwise, we need to set our estimation to None
-        else:
-            self.estimated_pos = None
-            self.estimated_angle = None
+#        # make sure that we aren't getting insane localization data
+#        if np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
+#            
+#            # plug this into an estimated pose in the map frame
+#            self.estimated_pos = Point(x,y,0)
+#            self.estimated_angle = delta
+#            
+#        # otherwise, we need to set our estimation to None
+#        else:
+#            self.estimated_pos = None
+#            self.estimated_angle = None
+#
+#        # update the previous so that we can continue annealing
+#        self._prev_est = [x, y, delta]
 
-        # update the previous so that we can continue annealing
-        self._prev_est = [x, y, delta]
-        
     def _tagCallback(self, data):
         """ Extract and process tag data from the ar_pose_marker topic. """
         if data.markers:
@@ -263,7 +267,7 @@ class Localization():
         
         if self.estimated_pos is None:
             return
-            
+        
         self._logger.csv(test_name + "_estimated", ["X", "Y", "yaw"], [self.estimated_pos.x, self.estimated_pos.y, self.estimated_angle], folder=folder)
 
     def csvLogRawTags(self, test_name, folder = "tests"):

--- a/localization.py
+++ b/localization.py
@@ -272,12 +272,12 @@ class Localization():
     
         self._prev_csv["estimated"] = csv_estimated
 
-    def csvLogRaw(self, test_name, folder = "tests"):
+    def csvLogRawTags(self, test_name, folder = "tests"):
         """ Log new raw tag data in separate files. """
         
         self._csvLogAR(test_name, self.tags, "raw", folder)
 
-    def csvLogRelative(self, test_name, folder = "tests"):
+    def csvLogRelativeTags(self, test_name, folder = "tests"):
         """ Log new position of AR tags relative to the robot base in separate files. """
 
         self._csvLogAR(test_name, self.tags_base, "relative", folder)
@@ -304,7 +304,7 @@ if __name__ == "__main__":
         def main(self):
             """ Run main tests. """
             self.localization.csvLogEstimated(self.csvtestname)
-            self.localization.csvLogRaw(self.csvtestname)
+            self.localization.csvLogRawTags(self.csvtestname)
         
         def screenLog(self, landmark, id):
             """ Nicely parse landmarks into easily logable data. """

--- a/localization.py
+++ b/localization.py
@@ -135,7 +135,8 @@ class Localization():
         x = map.pose.position.x - r * cos(theta)
         y = map.pose.position.y - r * sin(theta)
         
-        if not (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
+        # make sure that we aren't getting insane localization data
+        if not np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
             self.estimated_pose = None
             self.estimated_angle = None
             
@@ -145,6 +146,7 @@ class Localization():
             self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
             self.estimated_angle = delta
 
+        # update the previous so that we can continue annealing
         self._prev_est = [x, y, delta]
         
     def _tagCallback(self, data):

--- a/localization.py
+++ b/localization.py
@@ -51,7 +51,6 @@ class Localization():
         self.tags_base = {}
         self.tags_odom = {}
         
-        
         # set estimated pose based on local landmarks to None and set up the landmark map
         #self.estimated_pos = None
         #self.estimated_angle = None
@@ -151,11 +150,12 @@ class Localization():
         except (TypeError, ValueError) as e:
             return
         
-        q = self.tags_odom[closest_id].orientation
-        
         self._transform["map_pos"] = self.floorplan[closest_id].pose.position
         self._transform["map_angle"] = self.floorplan[closest_id].angle
         self._transform["odom_pos"] = self.tags_odom[closest_id].pose.position
+
+        # extract euler angle
+        q = self.tags_odom[closest_id].pose.orientation
         self._transform["odom_angle"] = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
 #        
 #    def _estimatePose(self):

--- a/localization.py
+++ b/localization.py
@@ -263,8 +263,10 @@ class Localization():
         if self.estimated_pose is None:
             return
         
+        # get the estimated pose in a csv friendly form
         csv_estimated = self._csvPose(self.estimated_pose)
 
+        # check to make sure that the estimated pose has changed
         if not np.allclose(self._prev_csv["estimated"], csv_estimated):
             self._csvLog(test_name + "_estimated", csv_estimated, folder)
     
@@ -297,10 +299,6 @@ if __name__ == "__main__":
             landmark_orientations = {0:-pi/2, 1:pi/2}
             self.localization = Localization({},{},{},landmarks, landmark_positions, landmark_orientations)
             
-            self.prev = {}
-    
-            self.csvfields = ["X", "Y", "Z", "qX", "qY", "qZ", "qW", "roll", "pitch", "yaw"]
-            
             self.csvtestname = "estimation"
 
         def main(self):
@@ -313,13 +311,6 @@ if __name__ == "__main__":
             self.logger.info("Frame: " + str(landmark.header.frame_id))
             self.logOrientation(landmark, id)
             self.logPosition(landmark, id)
-    
-        def csvPose(self, landmark_pose):
-            """ Convert pose object into csv data. """
-            p = landmark_pose.position
-            q = landmark_pose.orientation
-            roll, pitch, yaw = tf.transformations.euler_from_quaternion([q.x,q.y,q.z,q.w])
-            return [p.x, p.y, p.z, q.x, q.y, q.z, q.w, roll, pitch, yaw]
             
         def logPosition(self, incoming_landmark, id):
             """ Print the position of landmarks in meters. """

--- a/localization.py
+++ b/localization.py
@@ -259,7 +259,9 @@ class Localization():
 
     def csvLogEstimated(self, test_name, folder = "tests"):
         """ Log current position estimate if different from last logging. """
-        
+        if self.estimated_pose is None:
+            return
+            
         csv_estimated = self._csvPose(self.estimated_pose)
 
         if not np.allclose(self._prev_csv["estimated"], csv_estimated):

--- a/localization.py
+++ b/localization.py
@@ -248,7 +248,7 @@ class Localization():
         tags = deepcopy(tags)
         
         for id in tags:
-            csv_tag = self._csvPose(tags[id])
+            csv_tag = self._csvPose(tags[id].pose)
             
             # check to see if we've encounted this id before
             if id not in self._prev_csv[tag_type] or not np.allclose(self._prev_csv[tag_type][id], csv_tag):

--- a/localization.py
+++ b/localization.py
@@ -39,7 +39,7 @@ class Localization():
             on the visible tags. None if no tags visible.
     """
     _AR_FOV_LIMIT = pi / 8  # radians
-    _AR_UPDATE_TIME = 0.05  # seconds
+    _AR_UPDATE_TIME = 0.0   # seconds
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging

--- a/localization.py
+++ b/localization.py
@@ -42,7 +42,7 @@ class Localization():
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging
         self._logger = Logger("Localization")
-        self._csvFields = ["X", "Y", "Z", "qX", "qY", "qZ", "qW", "roll", "pitch", "yaw"]
+        self._csvfields = ["X", "Y", "Z", "qX", "qY", "qZ", "qW", "roll", "pitch", "yaw"]
         self._prev_csv = {"estimated": 0, "raw": {}, "relative": {}}
         
         # store raw tag data, data in the odom frame, and data in the base frame
@@ -261,7 +261,7 @@ class Localization():
         """ Log current position estimate if different from last logging. """
         if self.estimated_pose is None:
             return
-            
+        
         csv_estimated = self._csvPose(self.estimated_pose)
 
         if not np.allclose(self._prev_csv["estimated"], csv_estimated):

--- a/localization.py
+++ b/localization.py
@@ -161,7 +161,7 @@ class Localization():
             self._transform["odom_pos"] = p
             self._transform["odom_angle"] = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
         else:
-            self._logger.debug("noisy signal. ignoring")
+            self._logger.warn("Noisy tag signal. Ignoring.")
 
         self._prev_odom = cur_odom
     

--- a/localization.py
+++ b/localization.py
@@ -150,8 +150,8 @@ class Localization():
         except (TypeError, ValueError) as e:
             return
         
-        self._transform["map_pos"] = self.floorplan[closest_id].pose.position
-        self._transform["map_angle"] = self.floorplan[closest_id].angle
+        self._transform["map_pos"] = self.floorplan.landmarks[closest_id].pose.position
+        self._transform["map_angle"] = self.floorplan.landmarks[closest_id].angle
         self._transform["odom_pos"] = self.tags_odom[closest_id].pose.position
 
         # extract euler angle

--- a/localization.py
+++ b/localization.py
@@ -39,7 +39,6 @@ class Localization():
             on the visible tags. None if no tags visible.
     """
     _AR_FOV_LIMIT = 2.0 * pi / 15.0  # radians
-    _AR_UPDATE_TIME = 0.25  # seconds
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging
@@ -141,14 +140,17 @@ class Localization():
         y = map.pose.position.y - r * sin(theta)
         
         # make sure that we aren't getting insane localization data and are sampling at our reduced rate
-        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05)
-            and self._prev_update_time - time() > self._AR_UPDATE_TIME):
+        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05):
             
             # plug this into an estimated pose in the map frame
             q = tf.transformations.quaternion_from_euler(0,0,delta)
             self.estimated_pose = Pose(Point(x,y,0), Quaternion(q[0], q[1], q[2], q[3]))
             self.estimated_angle = delta
-            self._prev_update_time += self._AR_UPDATE_TIME
+            
+        # otherwise, we need to set our estimation to None
+        else:
+            self.estimated_pose = None
+            self.estimated_angle = None
 
         # update the previous so that we can continue annealing
         self._prev_est = [x, y, delta]

--- a/localization.py
+++ b/localization.py
@@ -156,6 +156,8 @@ class Localization():
         # extract euler angle
         q = self.tags_odom[closest_id].pose.orientation
         self._transform["odom_angle"] = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
+        
+        self._logger.debug(self._transform)
     
 #    def _estimatePose(self):
 #        """ Estimate current position based on proximity to landmarks. """

--- a/localization.py
+++ b/localization.py
@@ -155,7 +155,7 @@ class Localization():
 
         # check to make sure that we haven't just gotten a random noisy outlier.
         cur_odom = [p.x, p.y, p.z, q.x, q.y, q.z, q.w]
-        if np.allclose(self._prev_odom, cur_odom, atol = 0.1, rtol = 0.1)
+        if np.allclose(self._prev_odom, cur_odom, atol = 0.1, rtol = 0.05):
             self._transform["map_pos"] = self.floorplan.landmarks[closest_id].pose.position
             self._transform["map_angle"] = self.floorplan.landmarks[closest_id].angle
             self._transform["odom_pos"] = p

--- a/localization.py
+++ b/localization.py
@@ -141,8 +141,8 @@ class Localization():
         y = map.pose.position.y - r * sin(theta)
         
         # make sure that we aren't getting insane localization data and are sampling at our reduced rate
-        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05)
-            and self._prev_update_time - time() > self._AR_UPDATE_TIME):
+        if (np.allclose([x, y, delta], self._prev_est, atol = 0.1, rtol = 0.05)):
+            #and self._prev_update_time - time() > self._AR_UPDATE_TIME):
             
             # plug this into an estimated pose in the map frame
             q = tf.transformations.quaternion_from_euler(0,0,delta)

--- a/localization.py
+++ b/localization.py
@@ -39,7 +39,7 @@ class Localization():
             on the visible tags. None if no tags visible.
     """
     _AR_FOV_LIMIT = pi / 8  # radians
-    _AR_UPDATE_TIME = 0.25  # seconds
+    _AR_UPDATE_TIME = 0.1  # seconds
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging

--- a/localization.py
+++ b/localization.py
@@ -57,7 +57,7 @@ class Localization():
         #self.estimated_angle = None
         
         # set up the transformer between the map and ekf
-        self._transform = self._transform = {"map_pos": Point(), "map_angle": 0, "ekf_pos": Point(), "ekf_angle": 0}
+        self._transform = self._transform = {"map_pos": Point(), "map_angle": 0, "odom_pos": Point(), "odom_angle": 0}
         self.floorplan = FloorPlan(point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles)
         
         # smooth data by selectively sampling

--- a/localization.py
+++ b/localization.py
@@ -259,6 +259,7 @@ class Localization():
 
     def csvLogEstimated(self, test_name, folder = "tests"):
         """ Log current position estimate if different from last logging. """
+        
         if self.estimated_pose is None:
             return
         
@@ -305,6 +306,7 @@ if __name__ == "__main__":
         def main(self):
             """ Run main tests. """
             self.localization.csvLogEstimated(self.csvtestname)
+            self.localization.csvLogRaw(self.csvtestname)
         
         def screenLog(self, landmark, id):
             """ Nicely parse landmarks into easily logable data. """

--- a/localization.py
+++ b/localization.py
@@ -257,7 +257,7 @@ class Localization():
             # update the previous
             self._prev_csv[tag_type][id] = csv_tag
 
-    def csvLogEstimated(self, test_name, folder = None):
+    def csvLogEstimated(self, test_name, folder = "tests"):
         """ Log current position estimate if different from last logging. """
         
         if self.estimated_pose is None:
@@ -272,12 +272,12 @@ class Localization():
     
         self._prev_csv["estimated"] = csv_estimated
 
-    def csvLogRaw(self, test_name, folder = None):
+    def csvLogRaw(self, test_name, folder = "tests"):
         """ Log new raw tag data in separate files. """
         
         self._csvLogAR(test_name, self.tags, "raw", folder)
 
-    def csvLogRelative(self, test_name, folder = None):
+    def csvLogRelative(self, test_name, folder = "tests"):
         """ Log new position of AR tags relative to the robot base in separate files. """
 
         self._csvLogAR(test_name, self.tags_base, "relative", folder)

--- a/localization.py
+++ b/localization.py
@@ -39,7 +39,7 @@ class Localization():
             on the visible tags. None if no tags visible.
     """
     _AR_FOV_LIMIT = pi / 8  # radians
-    _AR_UPDATE_TIME = 0.1  # seconds
+    _AR_UPDATE_TIME = 0.05  # seconds
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging

--- a/localization.py
+++ b/localization.py
@@ -37,7 +37,7 @@ class Localization():
         self.estimated_pose (geometry_msgs.msg.Pose or None): The estimated pose of the robot based 
             on the visible tags. None if no tags visible.
     """
-    _AR_FOV_LIMIT = pi / 6 #2.0 * pi / 15
+    _AR_FOV_LIMIT = pi / 8 #2.0 * pi / 15
     
     def __init__(self, point_ids, locations, neighbors, landmark_ids, landmark_positions, landmark_angles):
         # set up logger and csv logging

--- a/localization.py
+++ b/localization.py
@@ -160,6 +160,8 @@ class Localization():
             self._transform["map_angle"] = self.floorplan.landmarks[closest_id].angle
             self._transform["odom_pos"] = p
             self._transform["odom_angle"] = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])[-1]
+        else:
+            self._logger.debug("noisy signal. ignoring")
 
         self._prev_odom = cur_odom
     

--- a/logger.py
+++ b/logger.py
@@ -84,14 +84,14 @@ class Logger:
         """ True if we've already started logging this test. """
         return tname in self._open_files
 
-    def csv(self, tname, fields, row folder = None, tolerance = None):
+    def csv(self, tname, fields, row, folder = None, tolerance = None):
         """ Log data to a CSV file of the form filename_YYYYMMDD-HHMMSS.csv. 
         
         Args:
             tname (str): The name of the test. Note that this is not the same as the path to the file;
                 rather, this should be descriptive of the test we are logging CSV data for.
+            fields (str list): The names of the columns in the csv file.
             row (list): The line to be added to the CSV file.
-            fields (str list): The names of the columns in the csv file
             folder (str, optional): The name of the local file we want to store the file in.
             tolerance (float, optional): The amount of difference between sequential arguments to the
                 csv writer to trigger a new line written. Larger tolerance will mean more time in between

--- a/logger.py
+++ b/logger.py
@@ -84,7 +84,7 @@ class Logger:
         """ True if we've already started logging this test. """
         return tname in self._open_files
 
-    def csv(self, tname, fields, row, folder = None, tolerance = None):
+    def csv(self, tname, fields, row, folder = None, tol = None):
         """ Log data to a CSV file of the form filename_YYYYMMDD-HHMMSS.csv. 
         
         Args:
@@ -93,7 +93,7 @@ class Logger:
             fields (str list): The names of the columns in the csv file.
             row (list): The line to be added to the CSV file.
             folder (str, optional): The name of the local file we want to store the file in.
-            tolerance (float, optional): The amount of difference between sequential arguments to the
+            tol (float, optional): The amount of difference between sequential arguments to the
                 csv writer to trigger a new line written. Larger tolerance will mean more time in between
                 lines written to output files. By default, this tolerance is mostly in place to root out
                 identical lines, since these indicate that the data has not renewed.
@@ -122,7 +122,7 @@ class Logger:
             self._open_files[tname]["prev"] = 0
     
         # preappend the current time and write current line to file if it's changed since the last writing
-        if not allclose(self._open_files[tname]["prev"], row, atol = self._tolerance if tolerance is None else tolerance)
+        if not allclose(self._open_files[tname]["prev"], row, atol = self._tolerance if tol is None else tol):
             self._open_files[tname]["writer"].writerow([time() - self._start_time] + row)
             self._open_files[tname]["prev"] = row
 

--- a/logger.py
+++ b/logger.py
@@ -157,9 +157,8 @@ if __name__ == "__main__":
             self.logger.warn("Warn!")
             self.logger.warn("Method warn!", method="main")
             
-            self.logger.csv("test", ["hello", "world"])
-            self.logger.csv("test", [1, 3])
-            self.logger.csv("test2", ["hi", "again"])
+            self.logger.csv("test", ["hello", "world"], [1,3])
+            self.logger.csv("test", ["hello", "world"], [2,2])
 
             self.signal_shutdown("Logger test complete.")
 

--- a/logger.py
+++ b/logger.py
@@ -116,7 +116,7 @@ class Logger:
             self._open_files[tname]["writer"] = csv.writer(self._open_files[tname]["file"])
             
             # assume that the first message will be variable names
-            self._open_files[tname]["writer"].writerow(["Time"] + fieldnames)
+            self._open_files[tname]["writer"].writerow(["Time"] + fields)
             
             # keep track of previous entries so that we don't log the same data multiple times
             self._open_files[tname]["prev"] = 0

--- a/motion.py
+++ b/motion.py
@@ -106,9 +106,12 @@ class Motion():
     
     def linear_speed(self):
         """ Get the current linear speed of the robot. """
+        
         return self._move_cmd.linear.x
     
     def angular_speed(self):
+        """ Get the current angular velocity of the robot. """
+            
         return self._move_cmd.angular.z
 
     def stop(self, now=False): 

--- a/motion.py
+++ b/motion.py
@@ -104,12 +104,12 @@ class Motion():
         
         self._move_publisher.publish(self._move_cmd)
     
-    def linear_speed(self):
+    def linear_vel(self):
         """ Get the current linear speed of the robot. """
         
         return self._move_cmd.linear.x
     
-    def angular_speed(self):
+    def angular_vel(self):
         """ Get the current angular velocity of the robot. """
             
         return self._move_cmd.angular.z

--- a/motion.py
+++ b/motion.py
@@ -70,7 +70,7 @@ class Motion():
         #   this computed delta is used to gently change robot velocity
         return delta_time * float(accel)
     
-    def _linear_stop(self, now):
+    def _linearStop(self, now):
         """ Gently stop forward motion of robot. """
         
         # if we've slowed to or past 0, or the user wants to stop now, zero the linear command and reset states
@@ -86,7 +86,7 @@ class Motion():
 
         self.starting = False
 
-    def _rotational_stop(self, now):
+    def _rotationalStop(self, now):
         """ Stop the robot and handle associated housekeeping. """
         
         # if we've slowed to or past 0, or the user wants to stop now, zero the rotational command and reset states
@@ -104,12 +104,12 @@ class Motion():
         
         self._move_publisher.publish(self._move_cmd)
     
-    def linear_vel(self):
+    def linearVel(self):
         """ Get the current linear speed of the robot. """
         
         return self._move_cmd.linear.x
     
-    def angular_vel(self):
+    def angularVel(self):
         """ Get the current angular velocity of the robot. """
             
         return self._move_cmd.angular.z
@@ -120,27 +120,27 @@ class Motion():
         Args:
             now (bool): Robot stops immediately if true, else decelerates.
         """
-        self._linear_stop(now)
-        self._rotational_stop(now)
+        self._linearStop(now)
+        self._rotationalStop(now)
     
         self._publish()
 
-    def stop_linear(self, now=False):
+    def stopLinear(self, now=False):
         """ Stop robot's linear motion, immediately if necessary. 
         
         Args:
             now (bool): Robot's forward motion stops immediately if true, else decelerates.
         """
-        self._linear_stop(now)
+        self._linearStop(now)
         self._publish()
 
-    def stop_rotation(self, now=False):
+    def stopRotation(self, now=False):
         """ Stop the robot rotation, immediately if necessary. 
         
         Args:
             now (bool): Robot's rotational motion stops immediately if true, else decelerates.
         """
-        self._rotational_stop(now)
+        self._rotationalStop(now)
         self._publish()
 
     def turn(self, direction, speed = 1):
@@ -246,7 +246,7 @@ if __name__ == "__main__":
             # otherwise, just walk
             else:
                 if self.motion.turning:
-                    self.motion.stop_rotation()
+                    self.motion.stopRotation()
                 else:
                     self.motion.walk()
 

--- a/motion.py
+++ b/motion.py
@@ -103,6 +103,13 @@ class Motion():
         """ Output commands to the Turtlebot. """
         
         self._move_publisher.publish(self._move_cmd)
+    
+    def linear_speed(self):
+        """ Get the current linear speed of the robot. """
+        return self._move_cmd.linear.x
+    
+    def angular_speed(self):
+        return self._move_cmd.angular.z
 
     def stop(self, now=False): 
         """ Stop the robot, immediately if necessary.

--- a/navigation.py
+++ b/navigation.py
@@ -149,12 +149,8 @@ class Navigation(Motion):
             
             # we need to turn to reach our goal
             else:
-            
-                # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.stopping:
-                    self._motion.stop_linear(now = self._jerky)
                 
-                elif self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
+                if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
                     self._motion.stop_linear(now = self._jerky)
 
                 elif self._motion.starting:
@@ -181,7 +177,7 @@ class Navigation(Motion):
         """ Log the current turtlebot pose information. """
         
         # create csv dict and log data
-        self._logger.csv(test_name, ["X", "Y", "qZ", "qW", "yaw"],
+        self._logger.csv(test_name + "_ekf", ["X", "Y", "qZ", "qW", "yaw"],
                             [self.p.x, self.p.y, self.q.z, self.q.w, self.angle], folder = folder)
     
     def shutdown(self, rate):

--- a/navigation.py
+++ b/navigation.py
@@ -121,9 +121,6 @@ class Navigation(Motion):
                 y (float): The y coordinate of the desired location (in meters from the origin).
             """
             nav_val = self._getDestData(Point(x,y,0))
-            self._logger.debug(nav_val, var_name = "angle to turn")
-            
-            d2 = (x - self.p.x)**2 + (y - self.p.y)**2
             
             # did we reach our waypoint?
             if nav_val is True or self._reached_goal is True:

--- a/navigation.py
+++ b/navigation.py
@@ -163,7 +163,7 @@ class Navigation(Motion):
 #                    # otherwise, if we're just starting, stop entirely instead of stalling
 #                    elif self._motion.starting:
 #                        self._motion.stop_linear(now = self._jerky)
-                elif self.starting:
+                elif self._motion.starting:
                     self._motion.stop_linear(now = self._jerky)
             
                 # make sure we're turning in the correct direction, and stop the turn if we're not

--- a/navigation.py
+++ b/navigation.py
@@ -161,7 +161,7 @@ class Navigation(Motion):
                     angular_vel = self._motion.angular_vel()
                     
                     if np.nonzero(angular_vel):
-                        if np.isclose(dist, abs(linear_vel / angular_vel)), atol = .01):
+                        if np.isclose(dist, abs(linear_vel / angular_vel), atol = .01):
                             self._logger.debug("avoiding circle")
                             self._motion.stop_linear(now = self._jerky)
             

--- a/navigation.py
+++ b/navigation.py
@@ -156,7 +156,7 @@ class Navigation(Motion):
                         self._motion.stop_linear(now = self._jerky)
                 
                     # if we're moving in a circle around our target, we need to stop
-                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + sqrt(y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
+                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
                         self._motion.stop_linear(now = self._jerky)
             
                     # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace

--- a/navigation.py
+++ b/navigation.py
@@ -152,7 +152,7 @@ class Navigation(Motion):
             
                 # if we need to make a big turn and we're walking, stop before turning
                 if self._motion.stopping:
-                    self._motion.stop_linear(now = self._jerky)
+                    self._motion.stop(now = self._jerky)
                 
                 elif self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
                     self._motion.stop_linear(now = self._jerky)

--- a/navigation.py
+++ b/navigation.py
@@ -168,6 +168,7 @@ class Navigation(Motion):
         
         # open a new file if necessary
         if not self._logger.isLogging(test_name):
+            self._logger.debug("hello")
             self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"])
         
         self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
@@ -178,7 +179,6 @@ class Navigation(Motion):
         # open the file if necessary
         tname = "pose"
         if not self._logger.isLogging(tname):
-            self._logger.debug("hello")
             self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
 
         # make sure we have new data

--- a/navigation.py
+++ b/navigation.py
@@ -174,8 +174,8 @@ class Navigation(Motion):
                 if (nav_val <= 0) != (self._motion.turn_dir >= 0):
                     self._motion.stop_rotation(now = True)
                 
-                # perform our turn with awareness how far off the target direction we are
-                self._motion.turn(nav_val < 0, .25 if self._motion.walking else 1 #abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                # perform our turn # with awareness how far off the target direction we are
+                self._motion.turn(nav_val < 0, .25 if self._motion.walking else 1) #abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             # we're still moving towards our goal (or our stopping point)
             return False

--- a/navigation.py
+++ b/navigation.py
@@ -152,6 +152,29 @@ class Navigation(Motion):
                 # if we need to make a big turn and we're walking, stop before turning
                 if self._motion.walking and abs(nav_val) > self._PI_OVER_FOUR:
                     self._motion.stop_linear(now = self._jerky)
+                
+                # if we need to make a big turn and we're walking, stop before turning
+                if self._motion.walking:
+                    
+                    # get the distance between the robot and the destination
+                    dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)
+                    
+                    # get linear and anglular velocities
+                    linear_vel = self._motion.linear_vel()
+                    angular_vel = self._motion.angular_vel()
+                    bad_radius = False
+                    
+                    try:
+                        # if we're close to the described turn radius, or
+                        bad_radius = dist < abs(linear_vel / angular_vel - .01))
+                
+                    except ZeroDivisionError:
+                        pass
+            
+                    if self._stopping or bad_radius:
+                        self._logger.debug("avoiding circle")
+                        self._stopping
+                        self._motion.stop_linear(now = self.jerky)
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
                 elif self._motion.starting:

--- a/navigation.py
+++ b/navigation.py
@@ -8,7 +8,7 @@ import tf
 import numpy as np
 
 from geometry_msgs.msg import PoseWithCovarianceStamped, Point, Quaternion
-from math import atan2, pi
+from math import atan2, pi, sqrt
 from std_msgs.msg import Empty
 from time import time
 

--- a/navigation.py
+++ b/navigation.py
@@ -134,7 +134,6 @@ class Navigation(Motion):
                 
                 # let the user know that we made it!
                 else:
-                    self._logger.info("Arrived at " + str((x,y)) + " (absolute position is " + str((self.p.x, self.p.y)) + ")")
                     self._reached_goal = False
                     return True
             

--- a/navigation.py
+++ b/navigation.py
@@ -164,7 +164,7 @@ class Navigation(Motion):
             # we're still moving towards our goal (or our stopping point)
             return False
         
-    def csvLogArrival(self, test_name, x, y, folder = None):
+    def csvLogArrival(self, test_name, x, y, folder = "tests"):
         
         # open a new file if necessary
         if not self._logger.isLogging(test_name):

--- a/navigation.py
+++ b/navigation.py
@@ -252,6 +252,7 @@ if __name__ == "__main__":
             if not self.reached_corner[0]:
                 self.reached_corner[0] = self.navigation.goToPosition(0, 0)
                 if self.reached_corner[0]:
+                    self.logger.debug("logging")
                     self.navigation.csvLogArrival(self.filename, 0, 0)
         
             elif self.navigation.goToPosition(length, 0):

--- a/navigation.py
+++ b/navigation.py
@@ -151,7 +151,7 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking:
+                if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
                     self._motion.stop_linear(now = self._jerky)
 #                    if abs(nav_val) > self._PI_OVER_FOUR:
 #                        self._motion.stop_linear(now = self._jerky)

--- a/navigation.py
+++ b/navigation.py
@@ -35,7 +35,11 @@ class Navigation(Motion):
     # avoid recomputing constants
     _HALF_PI = pi / 2.0
     _TWO_PI = 2.0 * pi
-    _PI_OVER_FOUR = pi / 4.0
+    
+    # create thresholds
+    _MIN_STATIONARY_TURN_SPEED = 0.5
+    _MIN_MOVING_TURN_SPEED = 0.15
+    _MAX_MOVING_TURN = 0.1
     
     def __init__(self, jerky = False, walking_speed = 1):
     
@@ -147,7 +151,7 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking and abs(nav_val) > 0.1:
+                if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
                     self._motion.stop_linear(now = self._jerky)
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
@@ -159,7 +163,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
                 
                 # perform our turn with awareness how far off the target direction we are
-                self._motion.turn(nav_val < 0, abs(nav_val / pi) + (0.15 if self._motion.walking else 0.5))
+                self._motion.turn(nav_val < 0, abs(nav_val / pi) + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
             
             # we're still moving towards our goal (or our stopping point)
             return False

--- a/navigation.py
+++ b/navigation.py
@@ -122,8 +122,6 @@ class Navigation(Motion):
             """
             nav_val = self._getDestData(Point(x,y,0))
             
-            d2 = (x - self.p.x)**2 + (y - self.p.y)**2
-            
             # did we reach our waypoint?
             if nav_val is True or self._reached_goal is True:
             
@@ -148,7 +146,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
             
                 # onwards we go at the desired pace
-                self._motion.walk(speed = (self._walking_speed * (d2 + self._MIN_LINEAR_SPEED)))
+                self._motion.walk(speed = (self._walking_speed)
             
             # we need to turn to reach our goal
             else:
@@ -177,7 +175,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
                 
                 # perform our turn with awareness how far off the target direction we are
-                self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                self._motion.turn(nav_val < 0, .25 if self._motion.walking else 1 #abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             # we're still moving towards our goal (or our stopping point)
             return False

--- a/navigation.py
+++ b/navigation.py
@@ -41,6 +41,7 @@ class Navigation(Motion):
     _MIN_STATIONARY_TURN_SPEED = 0.5
     _MIN_MOVING_TURN_SPEED = 0.15
     _MAX_MOVING_TURN = pi / 6
+    _MIN_LINEAR_SPEED = .25
     
     def __init__(self, jerky = False, walking_speed = 1):
     
@@ -121,6 +122,8 @@ class Navigation(Motion):
             """
             nav_val = self._getDestData(Point(x,y,0))
             
+            dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)
+            
             # did we reach our waypoint?
             if nav_val is True or self._reached_goal is True:
             
@@ -145,7 +148,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
             
                 # onwards we go at the desired pace
-                self._motion.walk(speed=self._walking_speed)
+                self._motion.walk(speed = (self._walking_speed * (dist / 0.5 + self._MIN_LINEAR_SPEED)))
             
             # we need to turn to reach our goal
             else:

--- a/navigation.py
+++ b/navigation.py
@@ -105,7 +105,7 @@ class Navigation(Motion):
             return True
         
         # our orientation has gotten off and we need to adjust
-        elif not np.isclose(self.angle, turn_angle, atol=0.05):
+        elif not np.isclose(self.angle, turn_angle, atol=0.1):
             return self.angle - turn_angle
 
         # otherwise, move toward our goal

--- a/navigation.py
+++ b/navigation.py
@@ -156,16 +156,7 @@ class Navigation(Motion):
                 
                 elif self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
                     self._motion.stop_linear(now = self._jerky)
-#                    if abs(nav_val) > self._PI_OVER_FOUR:
-#                        self._motion.stop_linear(now = self._jerky)
-#                
-#                    # if we're moving in a circle around our target, we need to stop
-#                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
-#                        self._motion.stop_linear(now = self._jerky)
-#            
-#                    # otherwise, if we're just starting, stop entirely instead of stalling
-#                    elif self._motion.starting:
-#                        self._motion.stop_linear(now = self._jerky)
+
                 elif self._motion.starting:
                     self._motion.walk(speed=self._walking_speed)
             
@@ -174,7 +165,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
                 
                 # perform our turn # with awareness how far off the target direction we are
-                self._motion.turn(nav_val < 0, .25 if self._motion.walking else 1) #abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             # we're still moving towards our goal (or our stopping point)
             return False

--- a/navigation.py
+++ b/navigation.py
@@ -122,6 +122,8 @@ class Navigation(Motion):
             """
             nav_val = self._getDestData(Point(x,y,0))
             
+            d2 = (x - self.p.x)**2 + (y - self.p.y)**2
+            
             # did we reach our waypoint?
             if nav_val is True or self._reached_goal is True:
             

--- a/navigation.py
+++ b/navigation.py
@@ -169,7 +169,7 @@ class Navigation(Motion):
                         self._motion.stop_rotation(now = True)
                     
                     # perform our turn with awareness how far off the target direction we are
-                    self._motion.turn(nav_val < 0, abs(nav_val / pi) + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                    self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             # we're still moving towards our goal (or our stopping point)
             return False

--- a/navigation.py
+++ b/navigation.py
@@ -164,7 +164,7 @@ class Navigation(Motion):
 #                    elif self._motion.starting:
 #                        self._motion.stop_linear(now = self._jerky)
                 elif self._motion.starting:
-                    self._motion.stop_linear(now = self._jerky)
+                    self._motion.walk(speed=self._walking_speed)
             
                 # make sure we're turning in the correct direction, and stop the turn if we're not
                 if (nav_val <= 0) != (self._motion.turn_dir >= 0):

--- a/navigation.py
+++ b/navigation.py
@@ -171,6 +171,7 @@ class Navigation(Motion):
                     # perform our turn with awareness how far off the target direction we are
                     self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
+            self._logger.debug((self.p.x, self.p.y), var_name = "pos")
             # we're still moving towards our goal (or our stopping point)
             return False
         

--- a/navigation.py
+++ b/navigation.py
@@ -44,7 +44,7 @@ class Navigation(Motion):
         self._jerky = jerky
         self._walking_speed = min(abs(walking_speed), 1)
         self._logger = Logger("Navigation")
-        self._csv_prev = 0
+        self._prev_csv = {}
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = None
@@ -178,7 +178,7 @@ class Navigation(Motion):
         
         # open the file if necessary
         tname = test_name + "pose"
-        if not self._logger.isLogging(tname):
+        if not "pose" not in self._prev_csv:
             self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
 
         # make sure we have new data
@@ -187,7 +187,7 @@ class Navigation(Motion):
             self._logger.csv(tname, csv_data, folder = folder)
 
         # set the previous data to this data
-        self._csv_prev = csv_data
+        self._prev_csv["pose"] = csv_data
     
     def shutdown(self, rate):
         """ Stop the turtlebot. """

--- a/navigation.py
+++ b/navigation.py
@@ -159,9 +159,9 @@ class Navigation(Motion):
                     elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
                         self._motion.stop_linear(now = self._jerky)
             
-                    # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
+                    # otherwise, if we're just starting, stop entirely instead of stalling
                     elif self._motion.starting:
-                        self._motion.walk(speed=self._walking_speed)
+                        self._motion.stop_linear(now = self._jerky)
                     
                 # make sure we're turning in the correct direction, and stop the turn if we're not
                 if (nav_val <= 0) != (self._motion.turn_dir >= 0):

--- a/navigation.py
+++ b/navigation.py
@@ -147,7 +147,7 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking and abs(nav_val) > self._PI_OVER_FOUR:
+                if self._motion.walking and abs(nav_val) > 0.1:
                     self._motion.stop_linear(now = self._jerky)
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace

--- a/navigation.py
+++ b/navigation.py
@@ -38,7 +38,7 @@ class Navigation(Motion):
     _PI_OVER_FOUR = pi / 4.0
     
     # create thresholds
-    _MIN_STATIONARY_TURN_SPEED = 0.5
+    _MIN_STATIONARY_TURN_SPEED = 0.25
     _MIN_MOVING_TURN_SPEED = 0.15
     _MAX_MOVING_TURN = 0.1
     
@@ -105,7 +105,7 @@ class Navigation(Motion):
             return True
         
         # our orientation has gotten off and we need to adjust
-        elif not np.isclose(self.angle, turn_angle, atol=0.1):
+        elif not np.isclose(self.angle, turn_angle, atol=0.05):
             return self.angle - turn_angle
 
         # otherwise, move toward our goal

--- a/navigation.py
+++ b/navigation.py
@@ -168,9 +168,13 @@ class Navigation(Motion):
                     except ZeroDivisionError:
                         pass
             
-                    if self._motion.stopping or bad_radius:
+                    if self._stopping or bad_radius:
                         self._logger.debug("avoiding circle")
+                        self._stopping
                         self._motion.stop_linear()
+            
+                elif self._stopping:
+                    self._stopping = False
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
                 if self._motion.starting:

--- a/navigation.py
+++ b/navigation.py
@@ -168,12 +168,11 @@ class Navigation(Motion):
         
         # open a new file if necessary
         if not self._logger.isLogging(test_name):
-            self._logger.debug("hello")
             self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"])
         
         self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
     
-    def csvLogPose(self, folder = None):
+    def csvLogPose(self, folder = "tests"):
         """ Log the current turtlebot pose information. """
         
         # open the file if necessary

--- a/navigation.py
+++ b/navigation.py
@@ -151,7 +151,10 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
+                if self._motion.stopping:
+                    self._motion.stop_linear(now = self._jerky)
+                
+                elif self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
                     self._motion.stop_linear(now = self._jerky)
 #                    if abs(nav_val) > self._PI_OVER_FOUR:
 #                        self._motion.stop_linear(now = self._jerky)

--- a/navigation.py
+++ b/navigation.py
@@ -40,7 +40,7 @@ class Navigation(Motion):
     # create thresholds
     _MIN_STATIONARY_TURN_SPEED = 0.25
     _MIN_MOVING_TURN_SPEED = 0.15
-    _MAX_MOVING_TURN = 0.1
+    _MAX_MOVING_TURN = pi / 6
     
     def __init__(self, jerky = False, walking_speed = 1):
     

--- a/navigation.py
+++ b/navigation.py
@@ -170,7 +170,7 @@ class Navigation(Motion):
         if not self._logger.isLogging(test_name):
             self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"])
         
-        self._logger.csv(test_name, [x, y, self.navigation.p.x, self.navigation.p.y], folder = folder)
+        self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
     
     def csvLogPose(self, folder = None):
         """ Log the current turtlebot pose information. """

--- a/navigation.py
+++ b/navigation.py
@@ -160,7 +160,8 @@ class Navigation(Motion):
                     linear_vel = self._motion.linear_vel()
                     angular_vel = self._motion.angular_vel()
                     
-                    if np.isclose(dist, abs(linear_vel / angular_vel), atol = .01)atan2(0 - "Y", 1 - "X") - "yaw"
+                    if np.isclose(dist, abs(linear_vel / angular_vel), atol = .01):
+                        self._logger.debug("avoiding circle")
                         self._motion.stop_linear(now = self._jerky)
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace

--- a/navigation.py
+++ b/navigation.py
@@ -165,6 +165,7 @@ class Navigation(Motion):
             return False
         
     def csvLogArrival(self, test_name, x, y, folder = "tests"):
+        """ Log Turtlebot's arrival at a waypoint. """
         
         # open a new file if necessary
         if not self._logger.isLogging(test_name):
@@ -172,7 +173,7 @@ class Navigation(Motion):
         
         self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
     
-    def csvLogPose(self, test_name = "", folder = "tests"):
+    def csvLogEKF(self, test_name = "", folder = "tests"):
         """ Log the current turtlebot pose information. """
         
         # open the file if necessary

--- a/navigation.py
+++ b/navigation.py
@@ -151,8 +151,17 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
-                    self._motion.stop_linear(now = self._jerky)
+                if self._motion.walking:
+                    
+                    # get the distance between the robot and the destination
+                    dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)
+                    
+                    # get linear and anglular velocities
+                    linear_vel = self._motion.linear_vel()
+                    angular_vel = self._motion.angular_vel()
+                    
+                    if np.isclose(dist, abs(linear_vel / angular_vel), atol = .01)atan2(0 - "Y", 1 - "X") - "yaw"
+                        self._motion.stop_linear(now = self._jerky)
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
                 elif self._motion.starting:

--- a/navigation.py
+++ b/navigation.py
@@ -168,7 +168,7 @@ class Navigation(Motion):
         
         # open a new file if necessary
         if not self._logger.isLogging(test_name):
-            self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"])
+            self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = folder)
         
         self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
     

--- a/navigation.py
+++ b/navigation.py
@@ -163,14 +163,14 @@ class Navigation(Motion):
 #                    # otherwise, if we're just starting, stop entirely instead of stalling
 #                    elif self._motion.starting:
 #                        self._motion.stop_linear(now = self._jerky)
+                else:
+                    # make sure we're turning in the correct direction, and stop the turn if we're not
+                    if (nav_val <= 0) != (self._motion.turn_dir >= 0):
+                        self._motion.stop_rotation(now = True)
+                    
+                    # perform our turn with awareness how far off the target direction we are
+                    self._motion.turn(nav_val < 0, abs(nav_val / pi) + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
-                # make sure we're turning in the correct direction, and stop the turn if we're not
-                if (nav_val <= 0) != (self._motion.turn_dir >= 0):
-                    self._motion.stop_rotation(now = True)
-                
-                # perform our turn with awareness how far off the target direction we are
-                self._motion.turn(nav_val < 0, abs(nav_val / pi) + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
-            
             # we're still moving towards our goal (or our stopping point)
             return False
         

--- a/navigation.py
+++ b/navigation.py
@@ -142,7 +142,7 @@ class Navigation(Motion):
             
                 # if we're turning, we need to stop
                 if self._motion.turning:
-                    self._motion.stop_rotation(now = True)
+                    self._motion.stopRotation(now = True)
             
                 # onwards we go at the desired pace
                 self._motion.walk(speed = self._walking_speed)
@@ -151,14 +151,14 @@ class Navigation(Motion):
             else:
                 
                 if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
-                    self._motion.stop_linear(now = self._jerky)
+                    self._motion.stopLinear(now = self._jerky)
 
                 elif self._motion.starting:
                     self._motion.walk(speed=self._walking_speed)
             
                 # make sure we're turning in the correct direction, and stop the turn if we're not
                 if (nav_val <= 0) != (self._motion.turn_dir >= 0):
-                    self._motion.stop_rotation(now = True)
+                    self._motion.stopRotation(now = True)
                 
                 # perform our turn # with awareness how far off the target direction we are
                 self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))

--- a/navigation.py
+++ b/navigation.py
@@ -150,35 +150,17 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking and abs(nav_val) > self._PI_OVER_FOUR:
-                    self._motion.stop_linear(now = self._jerky)
-                
-                # if we need to make a big turn and we're walking, stop before turning
                 if self._motion.walking:
-                    
-                    # get the distance between the robot and the destination
-                    dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)
-                    
-                    # get linear and anglular velocities
-                    linear_vel = self._motion.linear_vel()
-                    angular_vel = self._motion.angular_vel()
-                    bad_radius = False
-                    
-                    try:
-                        # if we're close to the described turn radius, or
-                        bad_radius = dist < abs(linear_vel / angular_vel - .01))
+                    if abs(nav_val) > self._PI_OVER_FOUR:
+                        self._motion.stop_linear(now = self._jerky)
                 
-                    except ZeroDivisionError:
-                        pass
+                    # if we're moving in a circle around our target, we need to stop
+                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + sqrt(y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
+                        self._motion.stop_linear(now = self._jerky)
             
-                    if self._stopping or bad_radius:
-                        self._logger.debug("avoiding circle")
-                        self._stopping
-                        self._motion.stop_linear(now = self.jerky)
-            
-                # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
-                elif self._motion.starting:
-                    self._motion.walk(speed=self._walking_speed)
+                    # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
+                    elif self._motion.starting:
+                        self._motion.walk(speed=self._walking_speed)
                     
                 # make sure we're turning in the correct direction, and stop the turn if we're not
                 if (nav_val <= 0) != (self._motion.turn_dir >= 0):

--- a/navigation.py
+++ b/navigation.py
@@ -122,7 +122,7 @@ class Navigation(Motion):
             """
             nav_val = self._getDestData(Point(x,y,0))
             
-            dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)
+            d2 = (x - self.p.x)**2 + (y - self.p.y)**2
             
             # did we reach our waypoint?
             if nav_val is True or self._reached_goal is True:
@@ -148,7 +148,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
             
                 # onwards we go at the desired pace
-                self._motion.walk(speed = (self._walking_speed * (dist / 0.5 + self._MIN_LINEAR_SPEED)))
+                self._motion.walk(speed = (self._walking_speed * (dist / 0.25 + self._MIN_LINEAR_SPEED)))
             
             # we need to turn to reach our goal
             else:

--- a/navigation.py
+++ b/navigation.py
@@ -182,7 +182,7 @@ class Navigation(Motion):
 
         # make sure we have new data
         csv_data = [self.p.x, self.p.y, self.q.z, self.q.w, self.angle]
-        if np.allclose(self._csv_prev, csv_data)
+        if np.allclose(self._csv_prev, csv_data):
             self._logger.csv(tname, csv_data, folder = folder)
 
         # set the previous data to this data

--- a/navigation.py
+++ b/navigation.py
@@ -252,11 +252,11 @@ if __name__ == "__main__":
             if not self.reached_corner[0]:
                 self.reached_corner[0] = self.navigation.goToPosition(0, 0)
                 if self.reached_corner[0]:
-                    self.navigation.csvLogArrival("home", 0, 0)
+                    self.navigation.csvLogArrival(self.filename, 0, 0)
         
             elif self.navigation.goToPosition(length, 0):
                 self.reached_corner[0] = False
-                self.navigation.csvLogArrival("endpoint", length, 0)
+                self.navigation.csvLogArrival(self.filename, length, 0)
     
         def testCCsquare(self, length):
             """ Test a counter clockwise square. 
@@ -291,7 +291,7 @@ if __name__ == "__main__":
                 self.reached_corner[self.corner_counter] = self.navigation.goToPosition(corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
             
             else:
-                self.navigation.csvLogArrival("corner " + str(self.corner_counter), corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
+                self.navigation.csvLogArrival(self.filename, corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
                 if self.corner_counter == len(self.reached_corner) - 1:
                     self.reached_corner = [False] * len(self.reached_corner)
                 self.corner_counter = (self.corner_counter + 1) % len(self.reached_corner)

--- a/navigation.py
+++ b/navigation.py
@@ -154,27 +154,29 @@ class Navigation(Motion):
                 if self._motion.stopping:
                     self._motion.stop(now = self._jerky)
                 
-                elif self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
-                    self._motion.stop_linear(now = self._jerky)
-#                    if abs(nav_val) > self._PI_OVER_FOUR:
-#                        self._motion.stop_linear(now = self._jerky)
-#                
-#                    # if we're moving in a circle around our target, we need to stop
-#                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
-#                        self._motion.stop_linear(now = self._jerky)
-#            
-#                    # otherwise, if we're just starting, stop entirely instead of stalling
-#                    elif self._motion.starting:
-#                        self._motion.stop_linear(now = self._jerky)
-                elif self._motion.starting:
-                    self._motion.walk(speed=self._walking_speed)
-            
-                # make sure we're turning in the correct direction, and stop the turn if we're not
-                if (nav_val <= 0) != (self._motion.turn_dir >= 0):
-                    self._motion.stop_rotation(now = True)
+                else:
                 
-                # perform our turn with awareness how far off the target direction we are
-                self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                    if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
+                        self._motion.stop_linear(now = self._jerky)
+    #                    if abs(nav_val) > self._PI_OVER_FOUR:
+    #                        self._motion.stop_linear(now = self._jerky)
+    #                
+    #                    # if we're moving in a circle around our target, we need to stop
+    #                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
+    #                        self._motion.stop_linear(now = self._jerky)
+    #            
+    #                    # otherwise, if we're just starting, stop entirely instead of stalling
+    #                    elif self._motion.starting:
+    #                        self._motion.stop_linear(now = self._jerky)
+                    elif self._motion.starting:
+                        self._motion.walk(speed=self._walking_speed)
+                
+                    # make sure we're turning in the correct direction, and stop the turn if we're not
+                    if (nav_val <= 0) != (self._motion.turn_dir >= 0):
+                        self._motion.stop_rotation(now = True)
+                    
+                    # perform our turn with awareness how far off the target direction we are
+                    self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             self._logger.debug((self.p.x, self.p.y), var_name = "pos")
             # we're still moving towards our goal (or our stopping point)

--- a/navigation.py
+++ b/navigation.py
@@ -163,13 +163,15 @@ class Navigation(Motion):
 #                    # otherwise, if we're just starting, stop entirely instead of stalling
 #                    elif self._motion.starting:
 #                        self._motion.stop_linear(now = self._jerky)
-                else:
-                    # make sure we're turning in the correct direction, and stop the turn if we're not
-                    if (nav_val <= 0) != (self._motion.turn_dir >= 0):
-                        self._motion.stop_rotation(now = True)
-                    
-                    # perform our turn with awareness how far off the target direction we are
-                    self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                elif self.starting:
+                    self._motion.stop_linear(now = self._jerky)
+            
+                # make sure we're turning in the correct direction, and stop the turn if we're not
+                if (nav_val <= 0) != (self._motion.turn_dir >= 0):
+                    self._motion.stop_rotation(now = True)
+                
+                # perform our turn with awareness how far off the target direction we are
+                self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             self._logger.debug((self.p.x, self.p.y), var_name = "pos")
             # we're still moving towards our goal (or our stopping point)

--- a/navigation.py
+++ b/navigation.py
@@ -44,6 +44,7 @@ class Navigation(Motion):
         self._jerky = jerky
         self._walking_speed = min(abs(walking_speed), 1)
         self._logger = Logger("Navigation")
+        self._csv_prev = 0
 
         # subscibe to the robot_pose_ekf odometry information
         self.p = None
@@ -162,7 +163,31 @@ class Navigation(Motion):
             
             # we're still moving towards our goal (or our stopping point)
             return False
+        
+    def csvLogArrival(self, test_name, x, y, folder = None):
+        
+        # open a new file if necessary
+        if not self._logger.isLogging(test_name):
+            self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"])
+        
+        self._logger.csv(test_name, [x, y, self.navigation.p.x, self.navigation.p.y], folder = folder)
+    
+    def csvLogPose(self, folder = None):
+        """ Log the current turtlebot pose information. """
+        
+        # open the file if necessary
+        tname = "pose"
+        if not self._logger.isLogging(tname):
+            self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
 
+        # make sure we have new data
+        csv_data = [self.p.x, self.p.y, self.q.z, self.q.w, self.angle]
+        if np.allclose(self._csv_prev, csv_data)
+            self._logger.csv(tname, csv_data, folder = folder)
+
+        # set the previous data to this data
+        self._csv_prev = csv_data
+    
     def shutdown(self, rate):
         """ Stop the turtlebot. """
         

--- a/navigation.py
+++ b/navigation.py
@@ -241,11 +241,6 @@ if __name__ == "__main__":
             self.filename = filename + ("jerky" if self.jerky else "smooth")
             self.logger.csv(self.filename, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
-        def logArrival(self, name, x, y):
-            self.logger.info("Reached " + str(name) + " at " + str((x,y)))
-            self.logger.info("Current pose: " + str((self.navigation.p.x, self.navigation.p.y)))
-            self.logger.csv(self.filename, [x, y, self.navigation.p.x, self.navigation.p.y])
-        
         def testLine(self, length):
             """ Test behavior with a simple line. 
             
@@ -258,11 +253,11 @@ if __name__ == "__main__":
             if not self.reached_corner[0]:
                 self.reached_corner[0] = self.navigation.goToPosition(0, 0)
                 if self.reached_corner[0]:
-                    self.logArrival("home", 0, 0)
+                    self.navigation.logArrival("home", 0, 0)
         
             elif self.navigation.goToPosition(length, 0):
                 self.reached_corner[0] = False
-                self.logArrival("endpoint", length, 0)
+                self.navigation.logArrival("endpoint", length, 0)
     
         def testCCsquare(self, length):
             """ Test a counter clockwise square. 
@@ -297,7 +292,7 @@ if __name__ == "__main__":
                 self.reached_corner[self.corner_counter] = self.navigation.goToPosition(corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
             
             else:
-                self.logArrival("corner " + str(self.corner_counter), corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
+                self.navigation.logArrival("corner " + str(self.corner_counter), corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
                 if self.corner_counter == len(self.reached_corner) - 1:
                     self.reached_corner = [False] * len(self.reached_corner)
                 self.corner_counter = (self.corner_counter + 1) % len(self.reached_corner)

--- a/navigation.py
+++ b/navigation.py
@@ -151,7 +151,7 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking and self._motion.turning:
+                if self._motion.walking:
                     
                     # get the distance between the robot and the destination
                     dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)
@@ -160,12 +160,13 @@ class Navigation(Motion):
                     linear_vel = self._motion.linear_vel()
                     angular_vel = self._motion.angular_vel()
                     
-                    if np.isclose(dist, abs(linear_vel / angular_vel), atol = .01):
-                        self._logger.debug("avoiding circle")
-                        self._motion.stop_linear(now = self._jerky)
+                    if np.nonzero(angular_vel):
+                        if np.isclose(dist, abs(linear_vel / angular_vel)), atol = .01):
+                            self._logger.debug("avoiding circle")
+                            self._motion.stop_linear(now = self._jerky)
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
-                elif self._motion.starting:
+                if self._motion.starting:
                     self._motion.walk(speed=self._walking_speed)
                     
                 # make sure we're turning in the correct direction, and stop the turn if we're not

--- a/navigation.py
+++ b/navigation.py
@@ -148,7 +148,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
             
                 # onwards we go at the desired pace
-                self._motion.walk(speed = (self._walking_speed * (dist / 0.25 + self._MIN_LINEAR_SPEED)))
+                self._motion.walk(speed = (self._walking_speed * (d2 / 0.25 + self._MIN_LINEAR_SPEED)))
             
             # we need to turn to reach our goal
             else:

--- a/navigation.py
+++ b/navigation.py
@@ -38,7 +38,7 @@ class Navigation(Motion):
     _PI_OVER_FOUR = pi / 4.0
     
     # create thresholds
-    _MIN_STATIONARY_TURN_SPEED = 0.25
+    _MIN_STATIONARY_TURN_SPEED = 0.5
     _MIN_MOVING_TURN_SPEED = 0.15
     _MAX_MOVING_TURN = pi / 6
     
@@ -152,31 +152,29 @@ class Navigation(Motion):
             
                 # if we need to make a big turn and we're walking, stop before turning
                 if self._motion.stopping:
-                    self._motion.stop(now = self._jerky)
+                    self._motion.stop_linear(now = self._jerky)
                 
-                else:
+                elif self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
+                    self._motion.stop_linear(now = self._jerky)
+#                    if abs(nav_val) > self._PI_OVER_FOUR:
+#                        self._motion.stop_linear(now = self._jerky)
+#                
+#                    # if we're moving in a circle around our target, we need to stop
+#                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
+#                        self._motion.stop_linear(now = self._jerky)
+#            
+#                    # otherwise, if we're just starting, stop entirely instead of stalling
+#                    elif self._motion.starting:
+#                        self._motion.stop_linear(now = self._jerky)
+                elif self._motion.starting:
+                    self._motion.walk(speed=self._walking_speed)
+            
+                # make sure we're turning in the correct direction, and stop the turn if we're not
+                if (nav_val <= 0) != (self._motion.turn_dir >= 0):
+                    self._motion.stop_rotation(now = True)
                 
-                    if self._motion.walking and abs(nav_val) > self._MAX_MOVING_TURN:
-                        self._motion.stop_linear(now = self._jerky)
-    #                    if abs(nav_val) > self._PI_OVER_FOUR:
-    #                        self._motion.stop_linear(now = self._jerky)
-    #                
-    #                    # if we're moving in a circle around our target, we need to stop
-    #                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
-    #                        self._motion.stop_linear(now = self._jerky)
-    #            
-    #                    # otherwise, if we're just starting, stop entirely instead of stalling
-    #                    elif self._motion.starting:
-    #                        self._motion.stop_linear(now = self._jerky)
-                    elif self._motion.starting:
-                        self._motion.walk(speed=self._walking_speed)
-                
-                    # make sure we're turning in the correct direction, and stop the turn if we're not
-                    if (nav_val <= 0) != (self._motion.turn_dir >= 0):
-                        self._motion.stop_rotation(now = True)
-                    
-                    # perform our turn with awareness how far off the target direction we are
-                    self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
+                # perform our turn with awareness how far off the target direction we are
+                self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
             self._logger.debug((self.p.x, self.p.y), var_name = "pos")
             # we're still moving towards our goal (or our stopping point)

--- a/navigation.py
+++ b/navigation.py
@@ -163,7 +163,7 @@ class Navigation(Motion):
                     
                     try:
                         # if we're close to the described turn radius, or
-                        bad_radius = np.isclose(dist, abs(linear_vel / angular_vel), atol = .01)
+                        bad_radius = dist > abs(linear_vel / angular_vel - .01))
                 
                     except ZeroDivisionError:
                         pass

--- a/navigation.py
+++ b/navigation.py
@@ -35,6 +35,7 @@ class Navigation(Motion):
     # avoid recomputing constants
     _HALF_PI = pi / 2.0
     _TWO_PI = 2.0 * pi
+    _PI_OVER_FOUR = pi / 4.0
     
     # create thresholds
     _MIN_STATIONARY_TURN_SPEED = 0.5

--- a/navigation.py
+++ b/navigation.py
@@ -178,6 +178,7 @@ class Navigation(Motion):
         # open the file if necessary
         tname = "pose"
         if not self._logger.isLogging(tname):
+            self._logger.debug("hello")
             self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
 
         # make sure we have new data

--- a/navigation.py
+++ b/navigation.py
@@ -148,7 +148,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
             
                 # onwards we go at the desired pace
-                self._motion.walk(speed = (self._walking_speed * (d2 / 0.25 + self._MIN_LINEAR_SPEED)))
+                self._motion.walk(speed = (self._walking_speed * (d2 + self._MIN_LINEAR_SPEED)))
             
             # we need to turn to reach our goal
             else:

--- a/navigation.py
+++ b/navigation.py
@@ -130,7 +130,7 @@ class Navigation(Motion):
     
         # if we hit something or see something coming, stop
         # for now, we're keeping obstacle avoidance simple
-        elif self._sensors.bump or self.sensors.obstacle:
+        elif self._sensors.bump or self._sensors.obstacle:
             self._motion.stopLinear(now=True)
         
         # otherwise, did we reach our waypoint?

--- a/navigation.py
+++ b/navigation.py
@@ -146,7 +146,7 @@ class Navigation(Motion):
                     self._motion.stop_rotation(now = True)
             
                 # onwards we go at the desired pace
-                self._motion.walk(speed = (self._walking_speed)
+                self._motion.walk(speed = self._walking_speed)
             
             # we need to turn to reach our goal
             else:

--- a/navigation.py
+++ b/navigation.py
@@ -167,32 +167,22 @@ class Navigation(Motion):
     def csvLogArrival(self, test_name, x, y, folder = "tests"):
         """ Log Turtlebot's arrival at a waypoint. """
         
-        # open a new file if necessary
-        if not self._logger.isLogging(test_name):
-            self._logger.csv(test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = folder)
-        
-        self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
+        # send data to the csv logger
+        self._logger.csv(test_name, ["X_target", "Y_target", "X_reported", "Y_reported"],
+                            [x, y, self.p.x, self.p.y], folder = folder)
     
-    def csvLogEKF(self, test_name = "", folder = "tests"):
+    def csvLogEKF(self, test_name, folder = "tests"):
         """ Log the current turtlebot pose information. """
         
-        # open the file if necessary
-        tname = test_name + "pose"
-        if not "pose" not in self._prev_csv:
-            self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
-
-        # make sure we have new data
-        csv_data = [self.p.x, self.p.y, self.q.z, self.q.w, self.angle]
-        if np.allclose(self._csv_prev, csv_data):
-            self._logger.csv(tname, csv_data, folder = folder)
-
-        # set the previous data to this data
-        self._prev_csv["pose"] = csv_data
+        # create csv dict and log data
+        self._logger.csv(test_name, ["X", "Y", "qZ", "qW", "yaw"],
+                            [self.p.x, self.p.y, self.q.z, self.q.w, self.angle], folder = folder)
     
     def shutdown(self, rate):
         """ Stop the turtlebot. """
         
         self._motion.shutdown(rate)
+        self._logger.shutdown()
 
 if __name__ == "__main__":
     from tester import Tester

--- a/navigation.py
+++ b/navigation.py
@@ -121,6 +121,7 @@ class Navigation(Motion):
                 y (float): The y coordinate of the desired location (in meters from the origin).
             """
             nav_val = self._getDestData(Point(x,y,0))
+            self._logger.debug(nav_val, var_name = "angle to turn")
             
             d2 = (x - self.p.x)**2 + (y - self.p.y)**2
             
@@ -179,7 +180,6 @@ class Navigation(Motion):
                 # perform our turn with awareness how far off the target direction we are
                 self._motion.turn(nav_val < 0, abs(nav_val / self._HALF_PI)**2 + (self._MIN_MOVING_TURN_SPEED if self._motion.walking else self._MIN_STATIONARY_TURN_SPEED))
 
-            self._logger.debug((self.p.x, self.p.y), var_name = "pos")
             # we're still moving towards our goal (or our stopping point)
             return False
         

--- a/navigation.py
+++ b/navigation.py
@@ -160,10 +160,12 @@ class Navigation(Motion):
                     linear_vel = self._motion.linear_vel()
                     angular_vel = self._motion.angular_vel()
                     
-                    if np.nonzero(angular_vel):
+                    try:
                         if np.isclose(dist, abs(linear_vel / angular_vel), atol = .01):
                             self._logger.debug("avoiding circle")
                             self._motion.stop_linear(now = self._jerky)
+                    except ZeroDivisionError:
+                        pass
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
                 if self._motion.starting:

--- a/navigation.py
+++ b/navigation.py
@@ -168,7 +168,7 @@ class Navigation(Motion):
         """ Log Turtlebot's arrival at a waypoint. """
         
         # send data to the csv logger
-        self._logger.csv(test_name, ["X_target", "Y_target", "X_reported", "Y_reported"],
+        self._logger.csv(test_name + "_waypoints", ["X_target", "Y_target", "X_reported", "Y_reported"],
                             [x, y, self.p.x, self.p.y], folder = folder)
     
     def csvLogEKF(self, test_name, folder = "tests"):

--- a/navigation.py
+++ b/navigation.py
@@ -239,7 +239,6 @@ if __name__ == "__main__":
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """
             self.filename = filename + ("jerky" if self.jerky else "smooth")
-            self.logger.csv(self.filename, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def testLine(self, length):
             """ Test behavior with a simple line. 
@@ -253,11 +252,11 @@ if __name__ == "__main__":
             if not self.reached_corner[0]:
                 self.reached_corner[0] = self.navigation.goToPosition(0, 0)
                 if self.reached_corner[0]:
-                    self.navigation.logArrival("home", 0, 0)
+                    self.navigation.csvLogArrival("home", 0, 0)
         
             elif self.navigation.goToPosition(length, 0):
                 self.reached_corner[0] = False
-                self.navigation.logArrival("endpoint", length, 0)
+                self.navigation.csvLogArrival("endpoint", length, 0)
     
         def testCCsquare(self, length):
             """ Test a counter clockwise square. 
@@ -292,7 +291,7 @@ if __name__ == "__main__":
                 self.reached_corner[self.corner_counter] = self.navigation.goToPosition(corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
             
             else:
-                self.navigation.logArrival("corner " + str(self.corner_counter), corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
+                self.navigation.csvLogArrival("corner " + str(self.corner_counter), corners[self.corner_counter][0]*length, corners[self.corner_counter][1]*length)
                 if self.corner_counter == len(self.reached_corner) - 1:
                     self.reached_corner = [False] * len(self.reached_corner)
                 self.corner_counter = (self.corner_counter + 1) % len(self.reached_corner)

--- a/navigation.py
+++ b/navigation.py
@@ -163,18 +163,14 @@ class Navigation(Motion):
                     
                     try:
                         # if we're close to the described turn radius, or
-                        bad_radius = np.isclose(dist, abs(linear_vel / angular_vel), atol = .01) or self._stopping:
+                        bad_radius = np.isclose(dist, abs(linear_vel / angular_vel), atol = .01)
                 
                     except ZeroDivisionError:
                         pass
             
-                    if self._stopping or bad_radius:
+                    if self._motion.stopping or bad_radius:
                         self._logger.debug("avoiding circle")
-                        self._motion.stopping = True
-                        self.motion.stop_linear()
-            
-                elif self._motion.stopping:
-                    self.motion.stopping = False
+                        self._motion.stop_linear()
             
                 # otherwise, if we're just starting, get up to speed rather than stalling at an awkwardly slow pace
                 if self._motion.starting:

--- a/navigation.py
+++ b/navigation.py
@@ -152,17 +152,18 @@ class Navigation(Motion):
             
                 # if we need to make a big turn and we're walking, stop before turning
                 if self._motion.walking:
-                    if abs(nav_val) > self._PI_OVER_FOUR:
-                        self._motion.stop_linear(now = self._jerky)
-                
-                    # if we're moving in a circle around our target, we need to stop
-                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
-                        self._motion.stop_linear(now = self._jerky)
-            
-                    # otherwise, if we're just starting, stop entirely instead of stalling
-                    elif self._motion.starting:
-                        self._motion.stop_linear(now = self._jerky)
-                    
+                    self._motion.stop_linear(now = self._jerky)
+#                    if abs(nav_val) > self._PI_OVER_FOUR:
+#                        self._motion.stop_linear(now = self._jerky)
+#                
+#                    # if we're moving in a circle around our target, we need to stop
+#                    elif np.isclose(abs(sqrt((x - self.p.x)**2 + (y - self.p.y)**2) * self._motion.angular_vel()), self._motion.linear_vel(), atol = .1) or self._motion.stopping:
+#                        self._motion.stop_linear(now = self._jerky)
+#            
+#                    # otherwise, if we're just starting, stop entirely instead of stalling
+#                    elif self._motion.starting:
+#                        self._motion.stop_linear(now = self._jerky)
+
                 # make sure we're turning in the correct direction, and stop the turn if we're not
                 if (nav_val <= 0) != (self._motion.turn_dir >= 0):
                     self._motion.stop_rotation(now = True)

--- a/navigation.py
+++ b/navigation.py
@@ -172,11 +172,11 @@ class Navigation(Motion):
         
         self._logger.csv(test_name, [x, y, self.p.x, self.p.y], folder = folder)
     
-    def csvLogPose(self, folder = "tests"):
+    def csvLogPose(self, test_name = "", folder = "tests"):
         """ Log the current turtlebot pose information. """
         
         # open the file if necessary
-        tname = "pose"
+        tname = test_name + "pose"
         if not self._logger.isLogging(tname):
             self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
 

--- a/navigation.py
+++ b/navigation.py
@@ -151,7 +151,7 @@ class Navigation(Motion):
             else:
             
                 # if we need to make a big turn and we're walking, stop before turning
-                if self._motion.walking:
+                if self._motion.walking and self._motion.turning:
                     
                     # get the distance between the robot and the destination
                     dist = sqrt((x - self.p.x)**2 + (y - self.p.y)**2)

--- a/navloc.py
+++ b/navloc.py
@@ -89,6 +89,13 @@ class NavLoc(Navigation, Localization):
         qx, qy, qz, qw = tf.transformations.quaternion_from_euler(0, 0, self.angle)
         self.q = Quaternion(qx, qy, qz, qw)
 
+    def csvLogTransform(self, test_name):
+        """ Log the transformation from the ekf frame to the map frame. """
+    
+        tname = test_name + "_transform"
+        if not self._logger.isLogging(tname):
+            self._logger.csv(tname, "map_x", "map_y", "map_angle", "ekf_x", "ekf_y", "ekf_angle")
+
     def csvLogArrival(self, test_name, x, y):
         """ Log the arrival of the robot at a waypoint. """
     
@@ -108,7 +115,7 @@ class NavLoc(Navigation, Localization):
 
         # open the file if necessary
         tname = test_name + "_ekfpose"
-        if not self._logger.isLogging(tname):
+        if "ekf" not in self._prev_csv:
             self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
 
         # make sure we have new data
@@ -117,7 +124,7 @@ class NavLoc(Navigation, Localization):
             self._logger.csv(tname, csv_data, folder = folder)
 
         # set the previous data to this data
-        self._csv_prev = csv_data
+        self._prev_csv["ekf"] = csv_data
 
 if __name__ == "__main__":
     from tester import Tester

--- a/navloc.py
+++ b/navloc.py
@@ -113,8 +113,7 @@ class NavLoc(Navigation, Localization):
                             
         self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf", "angle_delta"],
                     [self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"],
-                            self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"],
-                            self._transform["angle_delta"]],
+                            self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"]],
                     folder = folder)
 
     def csvLogArrival(self, test_name, x, y, folder = "tests"):

--- a/navloc.py
+++ b/navloc.py
@@ -158,6 +158,7 @@ if __name__ == "__main__":
             self.navloc.csvLogEKF(self.test_name)
             self.navloc.csvLogMap(self.test_name)
             self.navloc.csvLogTransform(self.test_name)
+            self.navloc.csvLogEstimate(self.test_name)
             self.navloc.csvLogRawTags(self.test_name)
             self.navloc.csvLogRelativeTags(self.test_name)
 

--- a/navloc.py
+++ b/navloc.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
             self.corner_counter = 0
         
             # set up the logger output file
-            self.filename = None
+            self.test_name = "debug"
         
             landmarks = {0}
             landmark_positions = {0:(1.75,0)}
@@ -165,6 +165,9 @@ if __name__ == "__main__":
             #self.testCCsquare(.5)
             #self.testCsquare(.5)
             self.testLine(1)
+            self.csvLogEKF(self.test_name)
+            self.csvLogMap(self.test_name)
+            self.csvLogTransform(self.test_name)
         
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """

--- a/navloc.py
+++ b/navloc.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
         def logArrival(self, name, x, y):
             self.logger.info("Reached " + str(name) + " at " + str((x,y)))
             self.logger.info("Current pose: " + str((self.navloc.p.x, self.navloc.p.y)))
-            self.navigation.csvLogArrival(self.test_name, x, y)
+            self.navloc.csvLogArrival(self.test_name, x, y)
         
         def testLine(self, length):
             """ Test behavior with a simple line. 

--- a/navloc.py
+++ b/navloc.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             self.logger.csv(self.test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def logArrival(self, name, x, y):
-            self.logger.info("Arrived at " + str((self.navloc.p.x, self.navloc.p.y)) + " (absolute position is " +
+            self.logger.info("Arrived at " + str((x, y)) + " (map position is " +
                 str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
             self.navloc.csvLogArrival(self.test_name, x, y)
         

--- a/navloc.py
+++ b/navloc.py
@@ -50,6 +50,9 @@ class NavLoc(Navigation, Localization):
         # save the estimated map position
         self._transform["map_pos"] = deepcopy(self.estimated_pos)
         self._transform["map_angle"] = self.estimated_angle
+        
+        self._logger.debug(self.estimated_pos, var_name = "estimated_pose")
+        self._logger.debug(self.estimated_angle, var_name = "estimated_angle")
     
     def _getDestData(self, destination):
         """ Move from current position to desired waypoint in the odomety frame.

--- a/navloc.py
+++ b/navloc.py
@@ -101,7 +101,7 @@ class NavLoc(Navigation, Localization):
     def csvLogArrival(self, test_name, x, y, folder = "tests"):
         """ Log the arrival of the robot at a waypoint. """
         
-        self._logger.csv(test_name, ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],
+        self._logger.csv(test_name + "_waypoints", ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],
                     [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y], folder = folder)
 
     def csvLogMap(self, test_name, folder = "tests"):

--- a/navloc.py
+++ b/navloc.py
@@ -34,26 +34,26 @@ class NavLoc(Navigation, Localization):
 
         self._logger = Logger("NavLoc")
     
-    def _estimatePose(self):
-        """ Override pose estimation to include pose calculation. """
-    
-        Localization._estimatePose(self)
-        
-        # if there is currently no estimated pose, nothing more to do here
-        if self.estimated_pos is None:
-            return
-        
-        # save current odometry position
-        self._transform["ekf_pos"] = deepcopy(self.p)
-        self._transform["ekf_angle"] = self.angle
+#    def _estimatePose(self):
+#        """ Override pose estimation to include pose calculation. """
+#    
+#        Localization._estimatePose(self)
+#        
+#        # if there is currently no estimated pose, nothing more to do here
+#        if self.estimated_pos is None:
+#            return
+#        
+#        # save current odometry position
+#        self._transform["ekf_pos"] = deepcopy(self.p)
+#        self._transform["ekf_angle"] = self.angle
+#
+#        # save the estimated map position
+#        self._transform["map_pos"] = deepcopy(self.estimated_pos)
+#        self._transform["map_angle"] = self.estimated_angle
+#        
+#        self._logger.debug(self.estimated_pos, var_name = "estimated_pose")
+#        self._logger.debug(self.estimated_angle, var_name = "estimated_angle")
 
-        # save the estimated map position
-        self._transform["map_pos"] = deepcopy(self.estimated_pos)
-        self._transform["map_angle"] = self.estimated_angle
-        
-        self._logger.debug(self.estimated_pos, var_name = "estimated_pose")
-        self._logger.debug(self.estimated_angle, var_name = "estimated_angle")
-    
     def _getDestData(self, destination):
         """ Move from current position to desired waypoint in the odomety frame.
             
@@ -67,7 +67,7 @@ class NavLoc(Navigation, Localization):
                 A negative value indicates that the desired angle is that many radians to the left of 
                 the current orientation, positive indicates the desired angle is to the right.
         """
-        return Navigation._getDestData(self, self._computeTransformation(destination, "map", "ekf"))
+        return Navigation._getDestData(self, self.transformPoint(destination, "map", "odom"))
     
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """

--- a/navloc.py
+++ b/navloc.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
             self.navloc.csvLogTransform(self.test_name)
             #self.navloc.csvLogEstimated(self.test_name)
             self.navloc.csvLogRawTags(self.test_name)
-            self.navloc.csvLogRelativeTags(self.test_name)
+            self.navloc.csvLogOdomTags(self.test_name)
 
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """

--- a/navloc.py
+++ b/navloc.py
@@ -165,9 +165,9 @@ if __name__ == "__main__":
             #self.testCCsquare(.5)
             #self.testCsquare(.5)
             self.testLine(1)
-            self.csvLogEKF(self.test_name)
-            self.csvLogMap(self.test_name)
-            self.csvLogTransform(self.test_name)
+            self.navloc.csvLogEKF(self.test_name)
+            self.navloc.csvLogMap(self.test_name)
+            self.navloc.csvLogTransform(self.test_name)
         
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """

--- a/navloc.py
+++ b/navloc.py
@@ -155,10 +155,12 @@ if __name__ == "__main__":
             #self.testCCsquare(.5)
             #self.testCsquare(.5)
             self.testLine(1)
-            self.navloc.csvLogEKF(self.test_name)
-            self.navloc.csvLogMap(self.test_name)
-            self.navloc.csvLogTransform(self.test_name)
-        
+#            self.navloc.csvLogEKF(self.test_name)
+#            self.navloc.csvLogMap(self.test_name)
+#            self.navloc.csvLogTransform(self.test_name)
+#            self.navloc.csvLogRawTags(self.test_name)
+#            self.navloc.csvLogRelativeTags(self.test_name)
+
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """
             self.test_name = filename + ("jerky" if self.jerky else "smooth")
@@ -167,7 +169,7 @@ if __name__ == "__main__":
         def logArrival(self, name, x, y):
             self.logger.info("Reached " + str(name) + " at " + str((x,y)))
             self.logger.info("Current pose: " + str((self.navloc.p.x, self.navloc.p.y)))
-            self.logger.csv(self.test_name, [x, y, self.navloc.p.x, self.navloc.p.y])
+            self.navigation.csvLogArrival(self.test_name, x, y)
         
         def testLine(self, length):
             """ Test behavior with a simple line. 

--- a/navloc.py
+++ b/navloc.py
@@ -89,6 +89,36 @@ class NavLoc(Navigation, Localization):
         qx, qy, qz, qw = tf.transformations.quaternion_from_euler(0, 0, self.angle)
         self.q = Quaternion(qx, qy, qz, qw)
 
+    def csvLogArrival(self, test_name, x, y):
+        """ Log the arrival of the robot at a waypoint. """
+    
+        # open a new file if necessary
+        if not self._logger.isLogging(test_name):
+            self._logger.csv(test_name, ["target_map_x", "target_map_y", "reported_map_x", "reported_map_y", "ekf_x", "ekf_y"], folder = folder)
+        
+        self._logger.csv(test_name, [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y], folder = folder)
+
+    def csvLogMap(self, test_name, folder = "tests"):
+        """ Log map position data. """
+         
+        Navigation.csvLogEKF(self, test_name + "_map", folder)
+
+    def csvLogEKF(self, test_name, folder = "tests"):
+        """ Log raw EKF position data. """
+
+        # open the file if necessary
+        tname = test_name + "_ekfpose"
+        if not self._logger.isLogging(tname):
+            self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
+
+        # make sure we have new data
+        csv_data = [self._raw_pose.position.x, self._raw_pose.position.y, self._raw_pose.orientation.z, self._raw_pose.orientation.w, self._raw_angle]
+        if np.allclose(self._csv_prev, csv_data):
+            self._logger.csv(tname, csv_data, folder = folder)
+
+        # set the previous data to this data
+        self._csv_prev = csv_data
+
 if __name__ == "__main__":
     from tester import Tester
     from math import pi

--- a/navloc.py
+++ b/navloc.py
@@ -94,8 +94,8 @@ class NavLoc(Navigation, Localization):
         """ Log the transformation from the ekf frame to the map frame. """
                             
         self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf", "angle_delta"],
-                    [self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
-                            self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
+                    [self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"],
+                            self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"],
                             self._transform["angle_delta"]],
                     folder = folder)
 

--- a/navloc.py
+++ b/navloc.py
@@ -181,7 +181,8 @@ if __name__ == "__main__":
             self.logger.csv(self.test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def logArrival(self, name, x, y):
-            self._logger.info("Arrived at " + str((self.p.x,self.p.y)) + " (absolute position is " + str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
+            self.logger.info("Arrived at " + str((self.p.x,self.p.y)) + " (absolute position is " +
+                str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
             self.navloc.csvLogArrival(self.test_name, x, y)
         
         def testLine(self, length):

--- a/navloc.py
+++ b/navloc.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
             self.navloc.csvLogEKF(self.test_name)
             self.navloc.csvLogMap(self.test_name)
             self.navloc.csvLogTransform(self.test_name)
-            self.navloc.csvLogEstimate(self.test_name)
+            self.navloc.csvLogEstimated(self.test_name)
             self.navloc.csvLogRawTags(self.test_name)
             self.navloc.csvLogRelativeTags(self.test_name)
 

--- a/navloc.py
+++ b/navloc.py
@@ -44,10 +44,8 @@ class NavLoc(Navigation, Localization):
             return
         
         # save current odometry position
-        ekf_pose = deepcopy(self._raw_pose)
-        ekf_angle = self._raw_angle
-        self._transform["ekf_pos"] = ekf_pose.position
-        self._transform["ekf_angle"] = ekf_angle
+        self._transform["ekf_pos"] = deepcopy(self.p)
+        self._transform["ekf_angle"] = self.angle
 
         # save the estimated map position
         self._transform["map_pos"] = self.estimated_pose.position

--- a/navloc.py
+++ b/navloc.py
@@ -155,11 +155,11 @@ if __name__ == "__main__":
             #self.testCCsquare(.5)
             #self.testCsquare(.5)
             self.testLine(1)
-#            self.navloc.csvLogEKF(self.test_name)
-#            self.navloc.csvLogMap(self.test_name)
-#            self.navloc.csvLogTransform(self.test_name)
-#            self.navloc.csvLogRawTags(self.test_name)
-#            self.navloc.csvLogRelativeTags(self.test_name)
+            self.navloc.csvLogEKF(self.test_name)
+            self.navloc.csvLogMap(self.test_name)
+            self.navloc.csvLogTransform(self.test_name)
+            self.navloc.csvLogRawTags(self.test_name)
+            self.navloc.csvLogRelativeTags(self.test_name)
 
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """

--- a/navloc.py
+++ b/navloc.py
@@ -121,7 +121,7 @@ class NavLoc(Navigation, Localization):
 
         # make sure we have new data
         csv_data = [self._raw_pose.position.x, self._raw_pose.position.y, self._raw_pose.orientation.z, self._raw_pose.orientation.w, self._raw_angle]
-        if np.allclose(self._csv_prev, csv_data):
+        if np.allclose(self._prev_csv["ekf"], csv_data):
             self._logger.csv(tname, csv_data, folder = folder)
 
         # set the previous data to this data

--- a/navloc.py
+++ b/navloc.py
@@ -99,8 +99,8 @@ if __name__ == "__main__":
             self.test_name = "debug"
         
             landmarks = {0}
-            landmark_positions = {0:(1.75,0)}
-            landmark_orientations = {0:-pi/2}
+            landmark_positions = {0:(-.75,0)}
+            landmark_orientations = {0:pi/2}
         
             self.navloc = NavLoc({},{},{},landmarks, landmark_positions, landmark_orientations, jerky = self.jerky, walking_speed = self.walking_speed)
 

--- a/navloc.py
+++ b/navloc.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
             self.navloc.csvLogEKF(self.test_name)
             self.navloc.csvLogMap(self.test_name)
             self.navloc.csvLogTransform(self.test_name)
-            self.navloc.csvLogEstimated(self.test_name)
+            #self.navloc.csvLogEstimated(self.test_name)
             self.navloc.csvLogRawTags(self.test_name)
             self.navloc.csvLogRelativeTags(self.test_name)
 

--- a/navloc.py
+++ b/navloc.py
@@ -121,7 +121,7 @@ class NavLoc(Navigation, Localization):
         """ Log the arrival of the robot at a waypoint. """
         
         self._logger.csv(test_name + "_waypoints", ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],
-                    [x, y, self.map_pos.x, self.map_pos.y],
+                    [x, y, self.map_pos.x, self.map_pos.y, self.p.x, self.p.y],
                     folder = folder)
 
     def csvLogMap(self, test_name, folder = "tests"):

--- a/navloc.py
+++ b/navloc.py
@@ -181,7 +181,8 @@ if __name__ == "__main__":
             self.logger.csv(self.test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def logArrival(self, name, x, y):
-            self.logger.info("Arrived at " + str((self.p.x,self.p.y)) + " (absolute position is " + str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
+            self.logger.info("Arrived at " + str((self.navloc.p.x, self.navloc.p.y)) + " (absolute position is " +
+                str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
             self.navloc.csvLogArrival(self.test_name, x, y)
         
         def testLine(self, length):

--- a/navloc.py
+++ b/navloc.py
@@ -171,13 +171,13 @@ if __name__ == "__main__":
         
         def initFile(self, filename):
             """ Write the first line of our outgoing file (variable names). """
-            self.filename = filename + ("jerky" if self.jerky else "smooth")
-            self.logger.csv(self.filename, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
+            self.test_name = filename + ("jerky" if self.jerky else "smooth")
+            self.logger.csv(self.test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def logArrival(self, name, x, y):
             self.logger.info("Reached " + str(name) + " at " + str((x,y)))
             self.logger.info("Current pose: " + str((self.navloc.p.x, self.navloc.p.y)))
-            self.logger.csv(self.filename, [x, y, self.navloc.p.x, self.navloc.p.y])
+            self.logger.csv(self.test_name, [x, y, self.navloc.p.x, self.navloc.p.y])
         
         def testLine(self, length):
             """ Test behavior with a simple line. 
@@ -185,7 +185,7 @@ if __name__ == "__main__":
             Args:
                 length (float): Length of the desired line (in meters).
             """
-            if self.filename is None:
+            if self.test_name is None:
                 self.initFile("line")
             
             if not self.reached_corner[0]:
@@ -203,7 +203,7 @@ if __name__ == "__main__":
             Args:
                 length (float): Length of the desired line (in meters).
             """
-            if self.filename is None:
+            if self.test_name is None:
                 self.initFile("counterclockwise")
             
             self.testSquare(length, self.cc_square)
@@ -214,7 +214,7 @@ if __name__ == "__main__":
             Args:
                 length (float): Length of the desired line (in meters).
             """
-            if self.filename is None:
+            if self.test_name is None:
                 self.initFile("clockwise")
             
             self.testSquare(length, self.c_square)

--- a/navloc.py
+++ b/navloc.py
@@ -181,8 +181,7 @@ if __name__ == "__main__":
             self.logger.csv(self.test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def logArrival(self, name, x, y):
-            self.logger.info("Arrived at " + str((self.p.x,self.p.y)) + " (absolute position is " +
-                str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
+            self.logger.info("Arrived at " + str((self.p.x,self.p.y)) + " (absolute position is " + str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
             self.navloc.csvLogArrival(self.test_name, x, y)
         
         def testLine(self, length):

--- a/navloc.py
+++ b/navloc.py
@@ -5,6 +5,7 @@ Author:
 """
 import tf
 import rospy
+import numpy as np
 
 from copy import deepcopy
 from geometry_msgs.msg import Pose, Point, Quaternion

--- a/navloc.py
+++ b/navloc.py
@@ -96,13 +96,15 @@ class NavLoc(Navigation, Localization):
         self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf", "angle_delta"],
                     [self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
                             self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
-                            self._transform["angle_delta"]], folder = folder)
+                            self._transform["angle_delta"]],
+                    folder = folder)
 
     def csvLogArrival(self, test_name, x, y, folder = "tests"):
         """ Log the arrival of the robot at a waypoint. """
         
         self._logger.csv(test_name + "_waypoints", ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],
-                    [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y], folder = folder)
+                    [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y],
+                    folder = folder)
 
     def csvLogMap(self, test_name, folder = "tests"):
         """ Log map position data. """
@@ -111,10 +113,10 @@ class NavLoc(Navigation, Localization):
 
     def csvLogEKF(self, test_name, folder = "tests"):
         """ Log raw EKF position data. """
-
-        csv_data = [self._raw_pose.position.x, self._raw_pose.position.y, self._raw_pose.orientation.z, self._raw_pose.orientation.w, self._raw_angle]
         
-        self._logger.csv(tname + "_ekfpose", ["X", "Y", "qZ", "qW", "yaw"], csv_data, folder = folder)
+        self._logger.csv(test_name + "_ekfpose", ["X", "Y", "qZ", "qW", "yaw"],
+                    [self._raw_pose.position.x, self._raw_pose.position.y, self._raw_pose.orientation.z, self._raw_pose.orientation.w, self._raw_angle],
+                    folder = folder)
 
 if __name__ == "__main__":
     from tester import Tester

--- a/navloc.py
+++ b/navloc.py
@@ -56,8 +56,6 @@ class NavLoc(Navigation, Localization):
         # compute the difference between them
         self._transform["angle_delta"] = self._transform["ekf_angle"] - self._transform["map_angle"]
         
-        self._logger.debug(self.estimated_pose, var_name = "estimated position \n")
-        
     def _ekfCallback(self, data):
         """ Process robot_pose_ekf data. """
         

--- a/navloc.py
+++ b/navloc.py
@@ -98,7 +98,7 @@ class NavLoc(Navigation, Localization):
                             self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
                             self._transform["angle_delta"]], folder = folder)
 
-    def csvLogArrival(self, test_name, x, y):
+    def csvLogArrival(self, test_name, x, y, folder = "tests"):
         """ Log the arrival of the robot at a waypoint. """
         
         self._logger.csv(test_name, ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],

--- a/navloc.py
+++ b/navloc.py
@@ -22,7 +22,7 @@ class NavLoc(Navigation, Localization):
         
         # create transformation object
         self._transform = {"map_pos": Point(0,0,0), "map_angle": 0, "ekf_pos": Point(0,0,0), "ekf_angle": 0}
-        self.map_position = Point()
+        self.map_pos = Point()
         self.map_angle = 0
     
         # initialize what we're inheriting from
@@ -99,7 +99,7 @@ class NavLoc(Navigation, Localization):
         Navigation._ekfCallback(self, data)
         
         # compute map data
-        self.map_position = self._computeTransformation(self.p, "ekf", "map")
+        self.map_pos = self._computeTransformation(self.p, "ekf", "map")
         self.map_angle = self._transform["map_angle"] + self.angle - self._transform["ekf_angle"]
         
         # wrap angle, if necessary

--- a/navloc.py
+++ b/navloc.py
@@ -90,7 +90,7 @@ class NavLoc(Navigation, Localization):
         qx, qy, qz, qw = tf.transformations.quaternion_from_euler(0, 0, self.angle)
         self.q = Quaternion(qx, qy, qz, qw)
 
-    def csvLogTransform(self, test_name):
+    def csvLogTransform(self, test_name, folder = "tests"):
         """ Log the transformation from the ekf frame to the map frame. """
                             
         self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf", "angle_delta"],

--- a/navloc.py
+++ b/navloc.py
@@ -98,6 +98,7 @@ if __name__ == "__main__":
             # set up the logger output file
             self.test_name = "debug"
         
+            # set map location of the landmark
             landmarks = {0}
             landmark_positions = {0:(-.75,0)}
             landmark_orientations = {0:pi/2}

--- a/navloc.py
+++ b/navloc.py
@@ -52,7 +52,7 @@ class NavLoc(Navigation, Localization):
         # save the estimated map position
         self._transform["map_pos"] = self.estimated_pose.position
         self._transform["map_angle"] = self.estimated_angle
-        
+    
     def _getDestData(self, destination):
         """ Move from current position to desired waypoint in the odomety frame.
             
@@ -181,8 +181,7 @@ if __name__ == "__main__":
             self.logger.csv(self.test_name, ["map_x", "map_y", "reported_x", "reported_y"], folder = "tests")
         
         def logArrival(self, name, x, y):
-            self.logger.info("Reached " + str(name) + " at " + str((x,y)))
-            self.logger.info("Current pose: " + str((self.navloc.p.x, self.navloc.p.y)))
+            self._logger.info("Arrived at " + str((self.p.x,self.p.y)) + " (absolute position is " + str((self.navloc.map_pos.x, self.navloc.map_pos.y)) + ")")
             self.navloc.csvLogArrival(self.test_name, x, y)
         
         def testLine(self, length):

--- a/navloc.py
+++ b/navloc.py
@@ -40,7 +40,7 @@ class NavLoc(Navigation, Localization):
         Localization._estimatePose(self)
         
         # if there is currently no estimated pose, nothing more to do here
-        if self.estimated_pose is None:
+        if self.estimated_pos is None:
             return
         
         # save current odometry position
@@ -48,7 +48,7 @@ class NavLoc(Navigation, Localization):
         self._transform["ekf_angle"] = self.angle
 
         # save the estimated map position
-        self._transform["map_pos"] = self.estimated_pose.position
+        self._transform["map_pos"] = deepcopy(self.estimated_pos)
         self._transform["map_angle"] = self.estimated_angle
     
     def _getDestData(self, destination):

--- a/navloc.py
+++ b/navloc.py
@@ -10,7 +10,6 @@ import numpy as np
 from copy import deepcopy
 from geometry_msgs.msg import Pose, Point, Quaternion
 from math import sin, cos, pi
-from time import time
 
 from localization import Localization
 from logger import Logger
@@ -33,26 +32,6 @@ class NavLoc(Navigation, Localization):
         self._timer = float('inf')
 
         self._logger = Logger("NavLoc")
-    
-#    def _estimatePose(self):
-#        """ Override pose estimation to include pose calculation. """
-#    
-#        Localization._estimatePose(self)
-#        
-#        # if there is currently no estimated pose, nothing more to do here
-#        if self.estimated_pos is None:
-#            return
-#        
-#        # save current odometry position
-#        self._transform["ekf_pos"] = deepcopy(self.p)
-#        self._transform["ekf_angle"] = self.angle
-#
-#        # save the estimated map position
-#        self._transform["map_pos"] = deepcopy(self.estimated_pos)
-#        self._transform["map_angle"] = self.estimated_angle
-#        
-#        self._logger.debug(self.estimated_pos, var_name = "estimated_pose")
-#        self._logger.debug(self.estimated_angle, var_name = "estimated_angle")
 
     def _getDestData(self, destination):
         """ Move from current position to desired waypoint in the odomety frame.
@@ -78,14 +57,6 @@ class NavLoc(Navigation, Localization):
         # compute map data
         self.map_pos = self.transformPoint(self.p, "odom", "map")
         self.map_angle = self.transformAngle(self.angle, "odom", "map")
-
-    def csvLogTransform(self, test_name, folder = "tests"):
-        """ Log the transformation from the ekf frame to the map frame. """
-                            
-        self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf", "angle_delta"],
-                    [self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"],
-                            self._transform["map_pos"].x, self._transform["map_pos"].y, self._transform["map_angle"]],
-                    folder = folder)
 
     def csvLogArrival(self, test_name, x, y, folder = "tests"):
         """ Log the arrival of the robot at a waypoint. """

--- a/navloc.py
+++ b/navloc.py
@@ -121,7 +121,7 @@ class NavLoc(Navigation, Localization):
         """ Log the arrival of the robot at a waypoint. """
         
         self._logger.csv(test_name + "_waypoints", ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],
-                    [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y],
+                    [x, y, self.map_pos.x, self.map_pos.y],
                     folder = folder)
 
     def csvLogMap(self, test_name, folder = "tests"):

--- a/navloc.py
+++ b/navloc.py
@@ -92,19 +92,17 @@ class NavLoc(Navigation, Localization):
 
     def csvLogTransform(self, test_name):
         """ Log the transformation from the ekf frame to the map frame. """
-    
-        tname = test_name + "_transform"
-        if not self._logger.isLogging(tname):
-            self._logger.csv(tname, "map_x", "map_y", "map_angle", "ekf_x", "ekf_y", "ekf_angle")
+                            
+        self._logger.csv(test_name + "_transform", ["X_map", "Y_map", "angle_map", "X_ekf", "Y_ekf", "angle_ekf", "angle_delta"],
+                    [self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
+                            self._transform["map_pos"].x, self._transform["map_pos"].y, self.transform["map_angle"],
+                            self._transform["angle_delta"]], folder = folder)
 
     def csvLogArrival(self, test_name, x, y):
         """ Log the arrival of the robot at a waypoint. """
-    
-        # open a new file if necessary
-        if not self._logger.isLogging(test_name):
-            self._logger.csv(test_name, ["target_map_x", "target_map_y", "reported_map_x", "reported_map_y", "ekf_x", "ekf_y"], folder = folder)
         
-        self._logger.csv(test_name, [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y], folder = folder)
+        self._logger.csv(test_name, ["X_target", "Y_target", "X_map", "Y_map", "X_ekf", "Y_ekf"],
+                    [x, y, self.p.x, self.p.y, self._raw_pose.position.x, self._raw_pose.position.y], folder = folder)
 
     def csvLogMap(self, test_name, folder = "tests"):
         """ Log map position data. """
@@ -114,18 +112,9 @@ class NavLoc(Navigation, Localization):
     def csvLogEKF(self, test_name, folder = "tests"):
         """ Log raw EKF position data. """
 
-        # open the file if necessary
-        tname = test_name + "_ekfpose"
-        if "ekf" not in self._prev_csv:
-            self._logger.csv(tname, ["X", "Y", "qZ", "qW", "yaw"], folder = folder)
-
-        # make sure we have new data
         csv_data = [self._raw_pose.position.x, self._raw_pose.position.y, self._raw_pose.orientation.z, self._raw_pose.orientation.w, self._raw_angle]
-        if np.allclose(self._prev_csv["ekf"], csv_data):
-            self._logger.csv(tname, csv_data, folder = folder)
-
-        # set the previous data to this data
-        self._prev_csv["ekf"] = csv_data
+        
+        self._logger.csv(tname + "_ekfpose", ["X", "Y", "qZ", "qW", "yaw"], csv_data, folder = folder)
 
 if __name__ == "__main__":
     from tester import Tester

--- a/obstacle_detection.py
+++ b/obstacle_detection.py
@@ -71,7 +71,7 @@ class ObstacleDetector():
         """
         extraction = self._extractObstruction(depth_img, self._OBSTACLE_SAMPLE_WIDTH)
         
-        if self._extract() is None:
+        if self._extractObstruction() is None:
             self.obstacle = True
             self.obstacle_dir = 0
             return False

--- a/obstacle_detection.py
+++ b/obstacle_detection.py
@@ -71,7 +71,7 @@ class ObstacleDetector():
         """
         extraction = self._extractObstruction(depth_img, self._OBSTACLE_SAMPLE_WIDTH)
         
-        if self._extractObstruction() is None:
+        if extraction is None:
             self.obstacle = True
             self.obstacle_dir = 0
             return False

--- a/safe_motion.py
+++ b/safe_motion.py
@@ -49,7 +49,7 @@ class SafeMotion(Motion):
         # if we hit something, stop
         elif self.sensors.bump:
             if self.walking:
-                Motion.stop_linear(self, now=True)
+                Motion.stopLinear(self, now=True)
             else:
                 self.avoiding = True
                 Motion.turn(self, self.sensors.bumper > 0)
@@ -57,7 +57,7 @@ class SafeMotion(Motion):
         # if we see something coming, avoid
         elif self.sensors.obstacle:
             if self.walking:
-                Motion.stop_linear(self)
+                Motion.stopLinear(self)
             else:
                 self.avoiding = True
                 Motion.turn(self, self.sensors.obstacle_dir > 0)
@@ -87,31 +87,31 @@ class SafeMotion(Motion):
 
         # if we hit something, stop now
         elif self.sensors.bump:
-            Motion.stop_linear(self, now=True)
+            Motion.stopLinear(self, now=True)
             
         # if we see something coming, stop gently
         elif self.sensors.obstacle:
-            Motion.stop_linear(self)
+            Motion.stopLinear(self)
         
         # otherwise, stay the course
         else:
             func(self, *args, **kwargs)
 
-    def stop_linear(self, now=False):
+    def stopLinear(self, now=False):
         """ Stop robot's linear motion, immediately if necessary. 
         
         Args:
             now (bool): Robot's forward motion stops immediately if true, else decelerates.
         """
-        self._safetyStop(Motion.stop_linear, now)
+        self._safetyStop(Motion.stopLinear, now)
 
-    def stop_rotation(self, now=False):
+    def stopRotation(self, now=False):
         """ Stop the robot rotation, immediately if necessary. 
         
         Args:
             now (bool): Robot's rotational motion stops immediately if true, else decelerates.
         """
-        self._safetyStop(Motion.stop_rotation, now)
+        self._safetyStop(Motion.stopRotation, now)
     
     def stop(self, now=False):
         """ Stop the robot, immediately if necessary.


### PR DESCRIPTION
Massively overhauled localization; create transformation between the AR tag's position in the odom frame and the AR tag's actual position on the map to create a map - odom transformation.
Keep transformations sane by sanity checking their values. Instead of making an estimated pose, Localization now creates a transformation between the map and odometry frames.
For now, we are computing the transformation based directly on this data rather than back tracking out the location of the robot; for our purposes, that step is unnecessary and introduces more noise and error than is good for us.

In NavLoc, the navigation section uses the odometry information to move, and goes to waypoints that have been transformed from the map to the odometry frames. It is important that robot navigation information be continuous; discrete jumps lead the robot to extremely strange behavior, whereas discrete jumps in the destination tend not to cause problems.

Update the logger to reject identical (or extremely similar) input, and allow user to set a threshold for similarity. This allows us to log information from the main control loop without having to worry about logging stale information.

Set up infrastructure in navigation for obstacle avoidance.
